### PR TITLE
fix(pipeline): fix sync job showing raw expression in name

### DIFF
--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -937,7 +937,7 @@ jobs:
   # SYNC MAIN TO DEV (After Release)
   # =============================================================================
   sync-to-dev:
-    name: 🔄 Sync main → ${{ needs.setup.outputs.sync-target-branch }}
+    name: 🔄 Sync to Dev
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
Static name instead of dynamic expression that shows raw in GitHub UI when skipped.