### PR TITLE
fix(deps): update stale action versions, fix DigitalOcean v2

### DIFF
--- a/.github/actions/deploy-digitalocean/action.yaml
+++ b/.github/actions/deploy-digitalocean/action.yaml
@@ -9,7 +9,8 @@ inputs:
 
   app-name:
     description: DigitalOcean App Platform app name
-    required: true
+    required: false
+    default: ""
 
   app-spec-location:
     description: Path to app spec file
@@ -23,17 +24,17 @@ inputs:
   is-pr-preview:
     description: Deploy as PR preview
     required: false
-    default: 'false'
+    default: "false"
 
   print-build-logs:
     description: Print build logs
     required: false
-    default: 'true'
+    default: "true"
 
   print-deploy-logs:
     description: Print deploy logs
     required: false
-    default: 'true'
+    default: "true"
 
 runs:
   using: composite
@@ -51,7 +52,7 @@ runs:
 
     - name: Deploy to DigitalOcean App Platform
       id: deploy
-      uses: digitalocean/app_action@5c95e0e12f850942e75d8903dc3be30cbea30953 # v1.1.7
+      uses: digitalocean/app_action/deploy@f4c57e650e1dec6665ad5d3af739b67b9d31aab1 # v2.0.10
       with:
         token: ${{ inputs.digitalocean-token }}
         app_name: ${{ inputs.app-name }}
@@ -70,13 +71,17 @@ runs:
         DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
       run: |
         set -euo pipefail
-        echo "### 🚀 DigitalOcean Deployment" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "- **App Name:** $APP_NAME" >> $GITHUB_STEP_SUMMARY
-        echo "- **Environment:** $ENVIRONMENT" >> $GITHUB_STEP_SUMMARY
-        echo "- **PR Preview:** $IS_PR_PREVIEW" >> $GITHUB_STEP_SUMMARY
         STATUS=$([[ "$DEPLOY_OUTCOME" == "success" ]] && echo "✅ Success" || echo "❌ Failed")
-        echo "- **Status:** $STATUS" >> $GITHUB_STEP_SUMMARY
+        {
+          echo "### 🚀 DigitalOcean Deployment"
+          echo ""
+          echo "| | |"
+          echo "|:---|:---|"
+          echo "| **App** | \`${APP_NAME}\` |"
+          echo "| **Environment** | \`${ENVIRONMENT}\` |"
+          echo "| **PR Preview** | \`${IS_PR_PREVIEW}\` |"
+          echo "| **Status** | ${STATUS} |"
+        } >> "$GITHUB_STEP_SUMMARY"
 
 outputs:
   deployment-url:

--- a/.github/actions/deploy-render/action.yaml
+++ b/.github/actions/deploy-render/action.yaml
@@ -113,7 +113,7 @@ runs:
 
     - name: Comment on Pull Request
       if: inputs.github-token != '' && inputs.comment-on-pr == 'true' && github.event_name == 'pull_request' && inputs.service-url != ''
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/.github/actions/deploy-vercel/action.yaml
+++ b/.github/actions/deploy-vercel/action.yaml
@@ -246,7 +246,7 @@ runs:
 
     - name: Comment on PR
       if: inputs.github-token != '' && inputs.environment == 'preview' && github.event_name == 'pull_request'
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -250,13 +250,13 @@ runs:
       if: >-
         steps.detect.outputs.stack == 'nodejs' &&
         steps.detect.outputs.package-manager == 'pnpm'
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       with:
         run_install: false
 
     - name: Setup Node.js (Strict Cache)
       if: steps.detect.outputs.stack == 'nodejs'
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: ${{ steps.detect.outputs.version }}
         cache:


### PR DESCRIPTION
Fix VS Code errors and stale action pins: DigitalOcean v1→v2 (fixes invalid inputs), github-script v7→v8 in deploy-vercel/render, setup-node v4→v6.3.0, pin pnpm/action-setup to SHA.