### PR TITLE
ci(release): auto-merge release-please PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,25 @@ jobs:
           config-file: .github/release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - name: 🤖 Enable auto-merge on release PR
+        if: steps.release.outputs.pr != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_OUTPUT: ${{ steps.release.outputs.pr }}
+        run: |
+          set -euo pipefail
+          # release-please may output PR as JSON object or plain number
+          if [[ "$PR_OUTPUT" =~ ^\{ ]]; then
+            pr_number=$(echo "$PR_OUTPUT" | jq -r '.number // empty')
+          else
+            pr_number="$PR_OUTPUT"
+          fi
+          if [[ -n "$pr_number" && "$pr_number" =~ ^[0-9]+$ ]]; then
+            echo "Enabling auto-merge for release PR #${pr_number}"
+            gh pr merge "$pr_number" --squash --auto
+          fi
+
   update-major-tag:
     name: 🏷️ Update Major Version Tag
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,9 @@ jobs:
           fi
           if [[ -n "$pr_number" && "$pr_number" =~ ^[0-9]+$ ]]; then
             echo "Enabling auto-merge for release PR #${pr_number}"
-            gh pr merge "$pr_number" --squash --auto
+            if ! gh pr merge "$pr_number" --squash --auto; then
+              echo "::warning::Could not enable auto-merge for release PR #${pr_number}; continuing without failing the workflow."
+            fi
           fi
 
   update-major-tag:


### PR DESCRIPTION
## Summary
- Enable auto-merge (squash) on release PRs created by release-please
- Handles both JSON and plain number PR output formats from release-please-action v4

## Prerequisites
Auto-merge requires branch protection rules with required status checks on `main`. If not configured, `gh pr merge --auto` will fail gracefully.

## Test plan
- [ ] Merge this PR, verify release-please PR #37 gets auto-merge enabled on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)