### PR TITLE
fix: preserve prerelease suffix in release version

### DIFF
--- a/.github/actions/release-management/action.yaml
+++ b/.github/actions/release-management/action.yaml
@@ -302,10 +302,13 @@ runs:
           release_major="$RP_MAJOR"
           release_minor="$RP_MINOR"
           release_patch="$RP_PATCH"
-          if [[ -n "$release_tag" ]]; then
-            release_version="${release_tag#v}"
+          # Extract semver from tag, handling both v1.2.3 and component-v1.2.3 formats
+          if [[ "$release_tag" =~ (^|-)v?([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?)$ ]]; then
+            release_version="${BASH_REMATCH[2]}"
           elif [[ -n "$release_major" && -n "$release_minor" && -n "$release_patch" ]]; then
             release_version="${release_major}.${release_minor}.${release_patch}"
+          elif [[ -n "$release_tag" ]]; then
+            release_version="${release_tag#v}"
           fi
 
           # release-please can return PR output as JSON; extract number cleanly.

--- a/.github/actions/release-management/action.yaml
+++ b/.github/actions/release-management/action.yaml
@@ -302,10 +302,10 @@ runs:
           release_major="$RP_MAJOR"
           release_minor="$RP_MINOR"
           release_patch="$RP_PATCH"
-          if [[ -n "$release_major" && -n "$release_minor" && -n "$release_patch" ]]; then
-            release_version="${release_major}.${release_minor}.${release_patch}"
-          elif [[ -n "$release_tag" ]]; then
+          if [[ -n "$release_tag" ]]; then
             release_version="${release_tag#v}"
+          elif [[ -n "$release_major" && -n "$release_minor" && -n "$release_patch" ]]; then
+            release_version="${release_major}.${release_minor}.${release_patch}"
           fi
 
           # release-please can return PR output as JSON; extract number cleanly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,17 @@ on:
   pull_request:
     branches: [main, dev]
 
+# Caller permissions cap reusable workflow job permissions.
+# Include all permissions needed by enabled pipeline stages.
+permissions:
+  contents: write          # releases, tag updates
+  pull-requests: write     # PR comments (deploy URLs, release PRs)
+  id-token: write          # OIDC for cloud providers + SLSA attestation
+  deployments: write       # deployment status updates
+  packages: write          # Docker/GHCR image push
+  attestations: write      # SLSA build provenance
+  security-events: write   # security scan SARIF uploads
+
 jobs:
   pipeline:
     uses: navigaite/.github/.github/workflows/universal-pipeline.yaml@v2


### PR DESCRIPTION
## Summary
- Fix release version output dropping prerelease suffix (e.g., `0.3.0-beta.1` → `0.3.0`)
- Prefer tag-derived version over `major.minor.patch` construction
- Ensures Docker images get correct prerelease tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)