### PR TITLE
perf(pipeline): allow skipped build for release/deploy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,12 +34,16 @@ jobs:
         shell: bash
         env:
           APP_ID: ${{ secrets.WORKFLOW_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.WORKFLOW_APP_PRIVATE_KEY }}
         run: |
-          if [[ -n "$APP_ID" ]]; then
+          if [[ -n "$APP_ID" && -n "$APP_PRIVATE_KEY" ]]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::WORKFLOW_APP_ID not set — falling back to GITHUB_TOKEN. Auto-merged PRs won't trigger follow-up workflows."
+            missing=()
+            [[ -z "$APP_ID" ]] && missing+=("WORKFLOW_APP_ID")
+            [[ -z "$APP_PRIVATE_KEY" ]] && missing+=("WORKFLOW_APP_PRIVATE_KEY")
+            echo "::warning::${missing[*]} not set — falling back to GITHUB_TOKEN. Auto-merged PRs won't trigger follow-up workflows."
           fi
 
       - name: 🔑 Generate GitHub App token


### PR DESCRIPTION
## Summary

- Release, deploy-docker, deploy-vercel, and deploy-digitalocean jobs now accept `skipped` build result (not just `success`)
- This enables calling workflows to pass `skip-build: true` on push events when PR validation already proved the code works
- Added missing `always()` to Vercel and DigitalOcean deploy conditions for correct evaluation when upstream jobs are skipped

## Context

When a calling workflow skips security/lint/test/build on push (because the PR already validated the same code), the build job result is `skipped`. Previously, release and deploy jobs required `success`, blocking the entire ship path.

## Test plan

- Verify existing workflows still work (build=success path unchanged)
- Test with edilio's `perf/skip-validation-on-push` branch which passes `skip-build: true` on push events