### PR TITLE
chore(release): auto-sync version in README and CLAUDE.md

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -22,7 +22,17 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "README.md"
+        },
+        {
+          "type": "generic",
+          "path": "CLAUDE.md"
+        }
+      ]
     }
   }
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,12 +34,16 @@ jobs:
         shell: bash
         env:
           APP_ID: ${{ secrets.WORKFLOW_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.WORKFLOW_APP_PRIVATE_KEY }}
         run: |
-          if [[ -n "$APP_ID" ]]; then
+          if [[ -n "$APP_ID" && -n "$APP_PRIVATE_KEY" ]]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::WORKFLOW_APP_ID not set — falling back to GITHUB_TOKEN. Auto-merged PRs won't trigger follow-up workflows."
+            missing=()
+            [[ -z "$APP_ID" ]] && missing+=("WORKFLOW_APP_ID")
+            [[ -z "$APP_PRIVATE_KEY" ]] && missing+=("WORKFLOW_APP_PRIVATE_KEY")
+            echo "::warning::${missing[*]} not set — falling back to GITHUB_TOKEN. Auto-merged PRs won't trigger follow-up workflows."
           fi
 
       - name: 🔑 Generate GitHub App token

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Navigaite Universal CI/CD Pipeline
 
-> Organization-wide reusable GitHub Actions pipeline (`navigaite/.github`), currently at **v2** (version 2.1.2).
+> Organization-wide reusable GitHub Actions pipeline (`navigaite/.github`), currently at **v2** (version 2.2.2). <!-- x-release-please-version -->
 
 ## What This Repo Is
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 The Universal Pipeline is a **reusable GitHub Actions workflow** that auto-detects your tech stack, runs security scans, lints, tests, builds, deploys, and releases — all from a single YAML config file.
 
-**Current version: `v2.1.0`** — consumers pin to `@v2` and always get the latest patch.
+**Current version: `v2.2.2`** — consumers pin to `@v2` and always get the latest patch. <!-- x-release-please-version -->
 
 ### Highlights
 


### PR DESCRIPTION
## Summary
- Configure release-please `extra-files` to auto-update version references in `README.md` and `CLAUDE.md` using `x-release-please-version` markers
- Update stale version strings to current `2.2.2`
- Check both App secrets before generating token in release workflow

## Test plan
- [ ] Verify release-please picks up the `extra-files` config on next release PR
- [ ] Confirm `x-release-please-version` markers are replaced correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)