### PR TITLE
fix: address security review findings

### DIFF
--- a/.github/actions/build-executable/action.yaml
+++ b/.github/actions/build-executable/action.yaml
@@ -65,7 +65,9 @@ runs:
         WORKING_DIR: ${{ inputs.working-directory }}
       run: |
         set -euo pipefail
-        if [[ "$WORKING_DIR" == *".."* ]] || [[ "$WORKING_DIR" == /* ]]; then
+        if [[ "$WORKING_DIR" == *".."* ]] || [[ "$WORKING_DIR" == /* ]] \
+          || [[ "$WORKING_DIR" == \\* ]] || [[ "$WORKING_DIR" == //* ]] \
+          || [[ "$WORKING_DIR" =~ ^[A-Za-z]:[\\/] ]]; then
           echo "::error::Invalid working-directory '$WORKING_DIR'. Must be a relative path without '..'"; exit 1
         fi
 

--- a/.github/actions/build-executable/action.yaml
+++ b/.github/actions/build-executable/action.yaml
@@ -59,6 +59,16 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Validate Inputs
+      shell: bash
+      env:
+        WORKING_DIR: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        if [[ "$WORKING_DIR" == *".."* ]] || [[ "$WORKING_DIR" == /* ]]; then
+          echo "::error::Invalid working-directory '$WORKING_DIR'. Must be a relative path without '..'"; exit 1
+        fi
+
     - name: Resolve Configuration
       id: resolve
       shell: bash

--- a/.github/actions/deploy-render/action.yaml
+++ b/.github/actions/deploy-render/action.yaml
@@ -56,6 +56,7 @@ runs:
         TIMEOUT_SECONDS: ${{ inputs.timeout-seconds }}
         SERVICE_NAME: ${{ inputs.service-name }}
       run: |
+        set -euo pipefail
         echo "::group::🚀 Triggering Render deploy for ${SERVICE_NAME}"
 
         if [[ -z "$DEPLOY_HOOK_URL" ]]; then
@@ -81,6 +82,7 @@ runs:
         SERVICE_URL: ${{ inputs.service-url }}
         ENVIRONMENT: ${{ inputs.environment }}
       run: |
+        set -euo pipefail
         GITHUB_DEPLOYMENTS_URL="https://github.com/${GITHUB_REPOSITORY}/deployments/activity_log?environment=${ENVIRONMENT}"
 
         if [[ -n "$SERVICE_URL" ]]; then
@@ -168,6 +170,7 @@ runs:
         RESOLVED_URL: ${{ steps.resolve.outputs.resolved-url }}
         DEPLOY_STATUS: ${{ steps.trigger.outcome == 'success' && '✅ Triggered' || '❌ Failed' }}
       run: |
+        set -euo pipefail
         {
           echo "### 🚀 Render Deployment"
           echo ""

--- a/.github/actions/deploy-vercel/action.yaml
+++ b/.github/actions/deploy-vercel/action.yaml
@@ -67,7 +67,9 @@ runs:
             exit 1
             ;;
         esac
-        if [[ "$WORKING_DIR" == *".."* ]] || [[ "$WORKING_DIR" == /* ]]; then
+        if [[ "$WORKING_DIR" == *".."* ]] || [[ "$WORKING_DIR" == /* ]] \
+          || [[ "$WORKING_DIR" == \\* ]] || [[ "$WORKING_DIR" == //* ]] \
+          || [[ "$WORKING_DIR" =~ ^[A-Za-z]:[\\/] ]]; then
           echo "::error::Invalid working-directory '$WORKING_DIR'. Must be a relative path without '..'"; exit 1
         fi
 

--- a/.github/actions/deploy-vercel/action.yaml
+++ b/.github/actions/deploy-vercel/action.yaml
@@ -73,7 +73,7 @@ runs:
 
     - name: Install Vercel CLI
       shell: bash
-      run: npm install -g vercel@latest
+      run: npm install -g vercel@51.2.1
 
     - name: Pull Vercel Environment
       shell: bash

--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -45,7 +45,9 @@ runs:
           nodejs|python|flutter) ;;
           *) echo "::error::Invalid stack '$STACK'. Must be one of: nodejs, python, flutter"; exit 1 ;;
         esac
-        if [[ "$WORKING_DIR" == *".."* ]] || [[ "$WORKING_DIR" == /* ]]; then
+        if [[ "$WORKING_DIR" == *".."* ]] || [[ "$WORKING_DIR" == /* ]] \
+          || [[ "$WORKING_DIR" == \\* ]] || [[ "$WORKING_DIR" == //* ]] \
+          || [[ "$WORKING_DIR" =~ ^[A-Za-z]:[\\/] ]]; then
           echo "::error::Invalid working-directory '$WORKING_DIR'. Must be a relative path without '..'"; exit 1
         fi
 

--- a/.github/actions/run-build/action.yaml
+++ b/.github/actions/run-build/action.yaml
@@ -56,7 +56,9 @@ runs:
           nodejs|python|flutter) ;;
           *) echo "::error::Invalid stack '$STACK'. Must be one of: nodejs, python, flutter"; exit 1 ;;
         esac
-        if [[ "$WORKING_DIR" == *".."* ]] || [[ "$WORKING_DIR" == /* ]]; then
+        if [[ "$WORKING_DIR" == *".."* ]] || [[ "$WORKING_DIR" == /* ]] \
+          || [[ "$WORKING_DIR" == \\* ]] || [[ "$WORKING_DIR" == //* ]] \
+          || [[ "$WORKING_DIR" =~ ^[A-Za-z]:[\\/] ]]; then
           echo "::error::Invalid working-directory '$WORKING_DIR'. Must be a relative path without '..'"; exit 1
         fi
 

--- a/.github/actions/run-lint/action.yaml
+++ b/.github/actions/run-lint/action.yaml
@@ -36,7 +36,9 @@ runs:
           nodejs|python|flutter) ;;
           *) echo "::error::Invalid stack '$STACK'. Must be one of: nodejs, python, flutter"; exit 1 ;;
         esac
-        if [[ "$WORKING_DIR" == *".."* ]] || [[ "$WORKING_DIR" == /* ]]; then
+        if [[ "$WORKING_DIR" == *".."* ]] || [[ "$WORKING_DIR" == /* ]] \
+          || [[ "$WORKING_DIR" == \\* ]] || [[ "$WORKING_DIR" == //* ]] \
+          || [[ "$WORKING_DIR" =~ ^[A-Za-z]:[\\/] ]]; then
           echo "::error::Invalid working-directory '$WORKING_DIR'. Must be a relative path without '..'"; exit 1
         fi
 

--- a/.github/actions/run-tests/action.yaml
+++ b/.github/actions/run-tests/action.yaml
@@ -36,7 +36,9 @@ runs:
           nodejs|python|flutter) ;;
           *) echo "::error::Invalid stack '$STACK'. Must be one of: nodejs, python, flutter"; exit 1 ;;
         esac
-        if [[ "$WORKING_DIR" == *".."* ]] || [[ "$WORKING_DIR" == /* ]]; then
+        if [[ "$WORKING_DIR" == *".."* ]] || [[ "$WORKING_DIR" == /* ]] \
+          || [[ "$WORKING_DIR" == \\* ]] || [[ "$WORKING_DIR" == //* ]] \
+          || [[ "$WORKING_DIR" =~ ^[A-Za-z]:[\\/] ]]; then
           echo "::error::Invalid working-directory '$WORKING_DIR'. Must be a relative path without '..'"; exit 1
         fi
 

--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -75,8 +75,10 @@ jobs:
           github.event_name == 'issue_comment' &&
           !contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.comment.author_association)
         shell: bash
+        env:
+          AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
         run: |
-          echo "::notice::Ignoring comment from non-member (association: ${{ github.event.comment.author_association }})"
+          echo "::notice::Ignoring comment from non-member (association: ${AUTHOR_ASSOCIATION})"
           exit 1
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/nightly-maintenance.yaml
+++ b/.github/workflows/nightly-maintenance.yaml
@@ -189,6 +189,12 @@ jobs:
     if: always()
     steps:
       - name: Generate summary
+        env:
+          RESULT_CLEANUP_WORKFLOWS: ${{ needs.cleanup-workflow-runs.result }}
+          RESULT_CLEANUP_CACHES: ${{ needs.cleanup-caches.result }}
+          RESULT_SECURITY_AUDIT: ${{ needs.security-audit.result }}
+          RESULT_DEPENDENCY_CHECK: ${{ needs.dependency-check.result }}
+          RESULT_LINT_WORKFLOWS: ${{ needs.lint-workflows.result }}
         run: |
           set -euo pipefail
           echo "### 🌙 Nightly Maintenance Summary" >> $GITHUB_STEP_SUMMARY
@@ -198,8 +204,8 @@ jobs:
 
           echo "| Task | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Workflow Cleanup | ${{ needs.cleanup-workflow-runs.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Cache Cleanup | ${{ needs.cleanup-caches.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Security Audit | ${{ needs.security-audit.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Dependency Check | ${{ needs.dependency-check.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Workflow Lint | ${{ needs.lint-workflows.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Workflow Cleanup | $RESULT_CLEANUP_WORKFLOWS |" >> $GITHUB_STEP_SUMMARY
+          echo "| Cache Cleanup | $RESULT_CLEANUP_CACHES |" >> $GITHUB_STEP_SUMMARY
+          echo "| Security Audit | $RESULT_SECURITY_AUDIT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Dependency Check | $RESULT_DEPENDENCY_CHECK |" >> $GITHUB_STEP_SUMMARY
+          echo "| Workflow Lint | $RESULT_LINT_WORKFLOWS |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- **H1**: Prevent script injection in `claude-code.yaml` — moved `github.event.comment.author_association` to `env:` var
- **H2**: Prevent script injection in `nightly-maintenance.yaml` — moved 5 `needs.*.result` expressions to `env:` vars
- **M3**: Add missing path traversal validation to `build-executable` action (all other actions already had it)
- **M4**: Add `set -euo pipefail` to 3 shell scripts in `deploy-render` action
- **M5**: Pin Vercel CLI to `v51.2.1` instead of `@latest` in `deploy-vercel` action

## Not addressed (by design)
- **M1** (internal action SHA-pinning): Architectural decision with trade-offs, not a quick fix
- **M2** (custom command documentation): Not a code change

## Test plan
- [ ] CI checks pass (actionlint + action validation tests)
- [ ] Verify `build-executable` rejects path traversal (covered by existing test pattern)
- [ ] Verify deploy-render scripts fail fast on errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)