### PR TITLE
fix: use GitHub App token for rolling tag updates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -103,10 +103,33 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release-created == 'true'
     steps:
+      - name: 🔍 Check for GitHub App secrets
+        id: check-app
+        shell: bash
+        env:
+          APP_ID: ${{ secrets.WORKFLOW_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.WORKFLOW_APP_PRIVATE_KEY }}
+        run: |
+          if [[ -n "$APP_ID" && -n "$APP_PRIVATE_KEY" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::GitHub App secrets not set — tag updates may fail due to tag protection rules."
+          fi
+
+      - name: 🔑 Generate GitHub App token
+        id: app-token
+        if: steps.check-app.outputs.available == 'true'
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.WORKFLOW_APP_ID }}
+          private-key: ${{ secrets.WORKFLOW_APP_PRIVATE_KEY }}
+
       - name: 📥 Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: 🏷️ Update rolling tags
         shell: bash
@@ -120,10 +143,8 @@ jobs:
 
           for ROLLING_TAG in "v${MAJOR}" "latest"; do
             echo "Updating ${ROLLING_TAG} to point to ${TAG}"
-            git tag -d "${ROLLING_TAG}" 2>/dev/null || true
-            git push origin ":refs/tags/${ROLLING_TAG}" 2>/dev/null || true
-            git tag "${ROLLING_TAG}" "${TAG}"
-            git push origin "${ROLLING_TAG}"
+            git tag -f "${ROLLING_TAG}" "${TAG}"
+            git push --force origin "refs/tags/${ROLLING_TAG}"
             echo "✅ ${ROLLING_TAG} → ${TAG}"
           done
 


### PR DESCRIPTION
## Summary
- The `update-major-tag` job used `GITHUB_TOKEN` which can't delete/force-push protected `v*` tags (blocked by org tag protection ruleset)
- Now uses the `navigaite-workflow-app` token (which has bypass permissions) and `git push --force` instead of delete+recreate

Fixes the `🏷️ Update Major Version Tag` failure on the latest release.

## Test plan
- [ ] CI passes
- [ ] After merge, re-run the failed release workflow or wait for next release to verify tag update succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)