### PR TITLE
fix(claude-code): use correct Copilot reviewer bot login

### DIFF
--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -18,7 +18,7 @@ name: 🤖 Claude Code
 #     claude:
 #       if: >-
 #         (github.event_name == 'pull_request_review' &&
-#           github.event.review.user.login == 'copilot[bot]') ||
+#           github.event.review.user.login == 'copilot-pull-request-reviewer[bot]') ||
 #         (github.event_name == 'pull_request_review_comment' &&
 #           contains(github.event.comment.body, '@claude')) ||
 #         (github.event_name == 'issue_comment' &&
@@ -45,7 +45,7 @@ on:
           Use '"*"' (quoted) to allow all bots. Empty string blocks all bots.
         required: false
         type: string
-        default: copilot[bot]
+        default: copilot-pull-request-reviewer[bot]
 
       timeout_minutes:
         description: Maximum minutes before the job is cancelled


### PR DESCRIPTION
## Summary
- GitHub's Copilot code review submits PR reviews as \`copilot-pull-request-reviewer[bot]\`, not \`copilot[bot]\`.
- Every Copilot-triggered run of the Claude auto-fix workflow was being skipped because both the example \`if:\` condition and the default \`allowed_bots\` input filtered on the wrong login.
- Fixes the two places (example docstring + \`allowed_bots\` default) so consumer repos calling this reusable workflow with defaults will trigger correctly.

## Test plan
- [ ] After merge + \`v2\` retag, update edilio's caller workflow to the same login and confirm a Copilot review submission triggers a Claude run on a fresh PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)