### PR TITLE
feat(maintenance): org-wide auto-upgrade bootstrap

### DIFF
--- a/.github/config/templates/dependabot.yml
+++ b/.github/config/templates/dependabot.yml
@@ -1,0 +1,31 @@
+# Managed by navigaite/.github bootstrap. Do not edit manually —
+# changes will be overwritten the next time bootstrap-maintenance.sh runs.
+#
+# Rationale:
+# - github-actions ecosystem catches third-party action bumps.
+# - The reusable `navigaite/.github` pipeline is pinned via rolling `@v2` tag,
+#   which release-please retargets on every release. Do NOT let Dependabot
+#   SHA-pin it — that would cause noise PRs on every pipeline patch.
+# - Native package ecosystems (npm, pip, docker, etc.) add themselves via
+#   repo-specific overrides; the bootstrap script appends them based on
+#   files detected in the repo.
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ['*']
+    ignore:
+      # Rolling major tag — never pin. Updates come from retagging in navigaite/.github.
+      - dependency-name: navigaite/.github/*
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/config/templates/trunk-upgrade.yaml
+++ b/.github/config/templates/trunk-upgrade.yaml
@@ -1,0 +1,19 @@
+# Managed by navigaite/.github bootstrap. Do not edit manually —
+# changes will be overwritten the next time bootstrap-maintenance.sh runs.
+#
+# The cron minute/hour is staggered per repo to avoid a PR storm across
+# all Navigaite repos. Bootstrap script substitutes __CRON__ at install time.
+---
+name: Trunk Upgrade
+
+on:
+  schedule:
+    - cron: '__CRON__'
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  upgrade:
+    uses: navigaite/.github/.github/workflows/trunk-upgrade.yaml@v2
+    secrets: inherit

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -1,0 +1,186 @@
+---
+name: 🌲 Trunk Upgrade
+
+# Reusable workflow that runs `trunk upgrade` in the calling repo,
+# opens a PR with any resulting changes, and enables auto-merge via the
+# Navigaite workflow GitHub App. Consumer repos call this weekly.
+#
+# Example consumer workflow (.github/workflows/trunk-upgrade.yaml):
+#
+#   name: Trunk Upgrade
+#   on:
+#     schedule:
+#       - cron: '0 6 * * 1'   # bootstrap script staggers this per repo
+#     workflow_dispatch: {}
+#   permissions: {}
+#   jobs:
+#     upgrade:
+#       uses: navigaite/.github/.github/workflows/trunk-upgrade.yaml@v2
+#       secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      pr_branch:
+        description: Branch name used for the upgrade PR
+        required: false
+        type: string
+        default: chore/trunk-upgrade
+      pr_title:
+        description: Title for the upgrade PR
+        required: false
+        type: string
+        default: 'chore(deps): trunk upgrade'
+      base_branch:
+        description: Base branch to target. Defaults to the repo's default branch.
+        required: false
+        type: string
+        default: ''
+    secrets:
+      WORKFLOW_APP_ID:
+        description: Navigaite workflow App ID (optional, falls back to GITHUB_TOKEN)
+        required: false
+      WORKFLOW_APP_PRIVATE_KEY:
+        description: Navigaite workflow App private key (optional)
+        required: false
+
+permissions: {}
+
+jobs:
+  upgrade:
+    name: 🌲 Trunk Upgrade
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate App token
+        id: app-token
+        if: env.HAS_APP == 'true'
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.4
+        with:
+          app-id: ${{ secrets.WORKFLOW_APP_ID }}
+          private-key: ${{ secrets.WORKFLOW_APP_PRIVATE_KEY }}
+        env:
+          HAS_APP: ${{ secrets.WORKFLOW_APP_ID != '' && secrets.WORKFLOW_APP_PRIVATE_KEY != '' }}
+
+      - name: Resolve token
+        id: token
+        shell: bash
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          FALLBACK: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$APP_TOKEN" ]]; then
+            echo "value=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "using=app" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=$FALLBACK" >> "$GITHUB_OUTPUT"
+            echo "using=github-token" >> "$GITHUB_OUTPUT"
+            echo "::notice::WORKFLOW_APP_ID not set; using GITHUB_TOKEN. PRs will not auto-merge."
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.token.outputs.value }}
+          fetch-depth: 0
+
+      - name: Resolve base branch
+        id: base
+        shell: bash
+        env:
+          INPUT_BASE: ${{ inputs.base_branch }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$INPUT_BASE" ]]; then
+            echo "name=$INPUT_BASE" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=$DEFAULT_BRANCH" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip if PR already open
+        id: guard
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.value }}
+          BRANCH: ${{ inputs.pr_branch }}
+        run: |
+          set -euo pipefail
+          OPEN=$(gh pr list --head "$BRANCH" --state open --json number --jq 'length')
+          if [[ "$OPEN" != "0" ]]; then
+            echo "::notice::An open PR already exists on $BRANCH; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip if no .trunk/trunk.yaml
+        if: steps.guard.outputs.skip == 'false'
+        id: trunk-present
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -f ".trunk/trunk.yaml" ]]; then
+            echo "::notice::No .trunk/trunk.yaml; nothing to upgrade."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Trunk
+        if: steps.guard.outputs.skip == 'false' && steps.trunk-present.outputs.present == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://trunk.io/releases/trunk -o /usr/local/bin/trunk
+          chmod +x /usr/local/bin/trunk
+          trunk --version
+
+      - name: Run trunk upgrade
+        if: steps.guard.outputs.skip == 'false' && steps.trunk-present.outputs.present == 'true'
+        id: upgrade
+        shell: bash
+        run: |
+          set -euo pipefail
+          trunk upgrade --ci
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Trunk is already up to date."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "::group::Trunk upgrade diff"
+            git diff --stat
+            echo "::endgroup::"
+          fi
+
+      - name: Create Pull Request
+        if: steps.upgrade.outputs.changed == 'true'
+        id: cpr
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ steps.token.outputs.value }}
+          branch: ${{ inputs.pr_branch }}
+          base: ${{ steps.base.outputs.name }}
+          commit-message: ${{ inputs.pr_title }}
+          title: ${{ inputs.pr_title }}
+          body: |
+            Automated `trunk upgrade` run.
+
+            Produced by [`navigaite/.github` trunk-upgrade workflow](https://github.com/navigaite/.github/blob/main/.github/workflows/trunk-upgrade.yaml).
+            Auto-merges after `Check Gate` passes.
+          delete-branch: true
+          signoff: true
+
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-number != '' && steps.token.outputs.using == 'app'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.value }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          set -euo pipefail
+          gh pr merge "$PR" --squash --auto
+          echo "::notice::Auto-merge enabled on PR #$PR"

--- a/docs/ORG_MAINTENANCE.md
+++ b/docs/ORG_MAINTENANCE.md
@@ -1,0 +1,55 @@
+# Org-wide Maintenance Automation
+
+This repo bootstraps two kinds of automatic upkeep into every `navigaite` org repo:
+
+1. **Dependabot** for the `github-actions` ecosystem (third-party action version bumps).
+2. **`trunk upgrade`** on a weekly schedule, staggered per repo, auto-merging after CI.
+
+It does **not** manage bumps of the reusable pipeline itself — consumers pin `navigaite/.github/...@v2`, and `release.yaml` retargets `v2` on every release. That gives zero-maintenance patch updates without producing a PR on every change.
+
+## Architecture
+
+| Piece                                          | Location                                                     | Role                                                                       |
+| ---------------------------------------------- | ------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| Reusable `trunk-upgrade.yaml`                  | `.github/workflows/trunk-upgrade.yaml` (this repo)           | Runs `trunk upgrade`, opens a PR, enables auto-merge via the workflow App. |
+| Consumer caller                                | `.github/workflows/trunk-upgrade.yaml` (each consumer repo)  | 10-line workflow with a staggered cron; calls the reusable workflow.       |
+| Dependabot config                              | `.github/dependabot.yml` (each consumer repo)                | Weekly grouped github-actions updates. Ignores `navigaite/.github/*`.      |
+| Bootstrap script                               | `scripts/bootstrap-maintenance.sh` (this repo)               | Pushes the two files above into every org repo via PRs. Idempotent.        |
+
+## Why this shape
+
+- **Rolling `@v2` over SHA pinning.** Pinning `navigaite/.github` to a SHA via Dependabot would create a PR on every pipeline patch across all 20 repos. The rolling tag already solves this without noise.
+- **Pull-based, not push-based.** Each repo owns its own schedule and `trunk upgrade` run. A central cron iterating all repos would be brittle and harder to debug.
+- **Staggered crons.** The bootstrap script deterministically hashes the repo name to a weekday + hour + minute window (Mon–Fri, 04:00–10:00 UTC) to spread PR creation across the week.
+- **App-owned auto-merge.** PRs auto-merge via `navigaite-workflow-app` after `Check Gate` passes. No human approval needed for routine linter bumps.
+- **Idempotent bootstrap.** Re-running the script is safe — it compares desired files against remote and opens a PR only when they differ.
+
+## Running the bootstrap
+
+```bash
+# Dry run (default)
+scripts/bootstrap-maintenance.sh
+
+# Apply across the whole org
+scripts/bootstrap-maintenance.sh --apply
+
+# Just two repos
+scripts/bootstrap-maintenance.sh --apply --only edilio,nvgt-github
+```
+
+Requires `gh` authenticated as an org admin (or a token generated from the workflow App with repo write) and `jq`.
+
+## What consumers see
+
+On merge of the bootstrap PR, the consumer repo gets:
+
+- **Weekly Monday morning Dependabot PR** grouping all `github-actions` bumps. Review + merge manually.
+- **Weekly `trunk upgrade` PR** on the repo's assigned day. Auto-merges after CI.
+
+Neither touches `.release-please-manifest.json`, `package.json`, or anything outside `.github/`.
+
+## Troubleshooting
+
+- **Trunk upgrade PRs stuck unmerged.** Check that the repo has `WORKFLOW_APP_ID` + `WORKFLOW_APP_PRIVATE_KEY` inherited from the org (they should be, for all Navigaite repos). Without them the workflow falls back to `GITHUB_TOKEN` and cannot enable auto-merge.
+- **Dependabot PRs for `navigaite/.github/*`.** Check the `ignore:` block in `.github/dependabot.yml`. The template excludes it explicitly.
+- **PR storm from the scheduled runs.** Staggering is across 140 slots (5 days × 7 hours × 4 quarter-hours). With ~20 repos, a few collisions are normal; since each PR lands in its own repo there's no actual conflict — at most a reviewer sees two trunk-upgrade PRs open at once. Not worth fixing.

--- a/scripts/bootstrap-maintenance.sh
+++ b/scripts/bootstrap-maintenance.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Bootstrap org-wide maintenance automation into every navigaite repo.
+#
+# What it does, per repo:
+#   1. Writes .github/dependabot.yml from templates/dependabot.yml
+#   2. Writes .github/workflows/trunk-upgrade.yaml from templates/trunk-upgrade.yaml
+#      with a staggered cron (hashed by repo name, Mon–Fri, 04:00–10:00 UTC)
+#   3. Opens a PR titled "chore(ci): bootstrap org maintenance automation"
+#      targeting the repo's default branch.
+#
+# Idempotent: if the files already match the templates, no PR is opened.
+# Respects an open existing bootstrap PR (skips that repo).
+#
+# Requirements:
+#   - gh CLI, authenticated as an org admin or via the workflow App
+#   - jq
+#   - Run from the root of navigaite/.github
+#
+# Usage:
+#   scripts/bootstrap-maintenance.sh                 # dry run, prints plan
+#   scripts/bootstrap-maintenance.sh --apply         # actually open PRs
+#   scripts/bootstrap-maintenance.sh --apply --only repo1,repo2
+#   scripts/bootstrap-maintenance.sh --org my-org    # override org name
+
+set -euo pipefail
+
+ORG="navigaite"
+APPLY=false
+ONLY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) APPLY=true; shift ;;
+    --org) ORG="$2"; shift 2 ;;
+    --only) ONLY="$2"; shift 2 ;;
+    -h|--help)
+      grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+command -v gh >/dev/null || { echo "gh CLI required" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq required" >&2; exit 1; }
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEPENDABOT_TEMPLATE="$REPO_ROOT/.github/config/templates/dependabot.yml"
+TRUNK_TEMPLATE="$REPO_ROOT/.github/config/templates/trunk-upgrade.yaml"
+
+[[ -f "$DEPENDABOT_TEMPLATE" ]] || { echo "Missing $DEPENDABOT_TEMPLATE" >&2; exit 1; }
+[[ -f "$TRUNK_TEMPLATE" ]] || { echo "Missing $TRUNK_TEMPLATE" >&2; exit 1; }
+
+# Deterministic stagger: hash(repo) → (day 1–5 Mon–Fri, hour 4–10 UTC, minute 0/15/30/45)
+stagger_cron() {
+  local repo="$1"
+  local hex day hour minute
+  hex="$(printf '%s' "$repo" | shasum -a 256 | cut -c1-8)"
+  local n=$((16#$hex))
+  day=$(( (n % 5) + 1 ))
+  hour=$(( ((n / 5) % 7) + 4 ))
+  minute=$(( ((n / 35) % 4) * 15 ))
+  printf '%d %d * * %d' "$minute" "$hour" "$day"
+}
+
+render_trunk_workflow() {
+  local repo="$1" cron
+  cron="$(stagger_cron "$repo")"
+  sed "s|__CRON__|$cron|" "$TRUNK_TEMPLATE"
+}
+
+list_repos() {
+  if [[ -n "$ONLY" ]]; then
+    IFS=',' read -ra arr <<< "$ONLY"
+    for r in "${arr[@]}"; do echo "$r"; done
+    return
+  fi
+  gh repo list "$ORG" --limit 200 --no-archived --json name,isPrivate \
+    | jq -r '.[].name'
+}
+
+fetch_remote_file() {
+  local repo="$1" path="$2"
+  gh api "repos/$ORG/$repo/contents/$path" --jq '.content' 2>/dev/null \
+    | base64 -d 2>/dev/null || true
+}
+
+plan_repo() {
+  local repo="$1"
+  local desired_dependabot desired_trunk current_dependabot current_trunk changes=()
+
+  desired_dependabot="$(cat "$DEPENDABOT_TEMPLATE")"
+  desired_trunk="$(render_trunk_workflow "$repo")"
+
+  current_dependabot="$(fetch_remote_file "$repo" ".github/dependabot.yml")"
+  current_trunk="$(fetch_remote_file "$repo" ".github/workflows/trunk-upgrade.yaml")"
+
+  [[ "$current_dependabot" != "$desired_dependabot" ]] && changes+=("dependabot.yml")
+  [[ "$current_trunk" != "$desired_trunk" ]] && changes+=("trunk-upgrade.yaml")
+
+  if [[ ${#changes[@]} -eq 0 ]]; then
+    echo "  [skip] $repo — already up to date"
+    return 1
+  fi
+
+  echo "  [plan] $repo — would update: ${changes[*]}"
+  return 0
+}
+
+apply_repo() {
+  local repo="$1"
+  local default_branch branch_name existing_pr
+  default_branch="$(gh api "repos/$ORG/$repo" --jq '.default_branch')"
+  branch_name="chore/bootstrap-maintenance"
+
+  existing_pr="$(gh pr list -R "$ORG/$repo" --head "$branch_name" --state open --json number --jq 'length' 2>/dev/null || echo 0)"
+  if [[ "$existing_pr" != "0" ]]; then
+    echo "  [skip] $repo — open bootstrap PR already exists"
+    return 0
+  fi
+
+  local workdir
+  workdir="$(mktemp -d)"
+  trap 'rm -rf "$workdir"' RETURN
+
+  git -C "$workdir" clone --depth 1 --branch "$default_branch" "https://github.com/$ORG/$repo.git" . >/dev/null 2>&1
+  git -C "$workdir" checkout -b "$branch_name"
+
+  mkdir -p "$workdir/.github/workflows"
+  cp "$DEPENDABOT_TEMPLATE" "$workdir/.github/dependabot.yml"
+  render_trunk_workflow "$repo" > "$workdir/.github/workflows/trunk-upgrade.yaml"
+
+  if git -C "$workdir" diff --quiet; then
+    echo "  [skip] $repo — nothing changed after clone"
+    return 0
+  fi
+
+  git -C "$workdir" add .github/dependabot.yml .github/workflows/trunk-upgrade.yaml
+  git -C "$workdir" -c user.name="navigaite-workflow-app[bot]" \
+                    -c user.email="navigaite-workflow-app[bot]@users.noreply.github.com" \
+                    commit -m "chore(ci): bootstrap org maintenance automation" >/dev/null
+
+  git -C "$workdir" push -u origin "$branch_name" >/dev/null 2>&1
+
+  gh pr create -R "$ORG/$repo" \
+    --base "$default_branch" \
+    --head "$branch_name" \
+    --title "chore(ci): bootstrap org maintenance automation" \
+    --body "Automated bootstrap from \`navigaite/.github\`. Adds weekly Dependabot updates (github-actions ecosystem) and a staggered \`trunk upgrade\` workflow that auto-merges after CI.
+
+Managed by \`scripts/bootstrap-maintenance.sh\` — edits to these files will be overwritten on the next bootstrap run." >/dev/null
+
+  echo "  [done] $repo — PR opened"
+}
+
+echo "Scanning $ORG repos…"
+mapfile -t REPOS < <(list_repos)
+echo "Found ${#REPOS[@]} repos"
+echo
+
+if ! $APPLY; then
+  echo "Dry run — no changes will be made. Pass --apply to open PRs."
+  echo
+  for r in "${REPOS[@]}"; do
+    plan_repo "$r" || true
+  done
+  exit 0
+fi
+
+for r in "${REPOS[@]}"; do
+  if plan_repo "$r"; then
+    apply_repo "$r"
+  fi
+done


### PR DESCRIPTION
## Summary
- Adds a reusable \`trunk-upgrade.yaml\` workflow + consumer templates + a bootstrap script that pushes them into every org repo.
- Keeps the rolling \`@v2\` tag for the reusable pipeline (no SHA-pinning via Dependabot — avoids a noise PR on every pipeline patch).
- Auto-merge of \`trunk upgrade\` PRs is owned by \`navigaite-workflow-app\`; Dependabot PRs (github-actions ecosystem) remain manual review.
- Design + rationale documented in \`docs/ORG_MAINTENANCE.md\`.

## Files
- \`.github/workflows/trunk-upgrade.yaml\` — reusable, called per repo.
- \`.github/config/templates/dependabot.yml\` — weekly grouped github-actions, ignores \`navigaite/.github/*\`.
- \`.github/config/templates/trunk-upgrade.yaml\` — caller template, cron substituted by bootstrap.
- \`scripts/bootstrap-maintenance.sh\` — idempotent PR opener, dry-run by default.
- \`docs/ORG_MAINTENANCE.md\` — design doc.

## Test plan
- [ ] Merge, wait for \`v2\` retag.
- [ ] Run \`scripts/bootstrap-maintenance.sh\` dry-run against \`navigaite\` org, verify the plan output lists all active repos.
- [ ] Run \`scripts/bootstrap-maintenance.sh --apply --only nvgt-github,edilio\` as a pilot, review the two PRs.
- [ ] After the pilot PRs merge, confirm the first scheduled \`trunk upgrade\` run fires and (if plugins drift) opens an auto-merging PR.
- [ ] Roll out \`--apply\` across the rest of the org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)