### PR TITLE
fix(templates): grant caller-level permissions for trunk-upgrade

### DIFF
--- a/.github/config/templates/trunk-upgrade.yaml
+++ b/.github/config/templates/trunk-upgrade.yaml
@@ -11,7 +11,12 @@ on:
     - cron: '__CRON__'
   workflow_dispatch: {}
 
-permissions: {}
+# Caller-level permissions cap the reusable workflow's job permissions.
+# The called workflow needs contents+pull-requests write to push a branch
+# and open a PR with the upgrade diff.
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   upgrade:


### PR DESCRIPTION
## Summary
The caller template shipped with \`permissions: {}\` at workflow level, which caps the reusable workflow's job permissions to zero. First \`workflow_dispatch\` run of the edilio pilot failed at startup with \`startup_failure\`.

Grants the minimum permissions the reusable workflow needs: \`contents: write\` (push the upgrade branch) and \`pull-requests: write\` (open the PR).

## Test plan
- [ ] After merge + \`v2\` retag, re-trigger the trunk-upgrade workflow in edilio and confirm it runs to completion (no startup_failure).