### PR TITLE
fix(claude-code): permissive trigger filter + always-on diagnostics

### DIFF
--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -16,15 +16,29 @@ name: 🤖 Claude Code
 #
 #   jobs:
 #     claude:
-#       # Permissive filter — exact-match on 'copilot-pull-request-reviewer[bot]'
-#       # was observed to silently skip in production (2026-04); use contains().
+#       # Review branch: permissive `contains(login, 'copilot')` because
+#       # exact-match on 'copilot-pull-request-reviewer[bot]' was observed
+#       # to silently skip in production (2026-04). Tightened by requiring
+#       # user.type == 'Bot' so a human account with "copilot" in the login
+#       # cannot trigger a privileged workflow.
+#       #
+#       # Comment branches: gate on the `@claude` keyword AND on
+#       # author_association so untrusted commenters cannot trigger runs.
+#       # Step-level check in this reusable workflow covers `issue_comment`
+#       # redundantly; adding it here saves runner spin-ups on both comment
+#       # event types.
 #       if: >-
 #         (github.event_name == 'pull_request_review' &&
+#           github.event.review.user.type == 'Bot' &&
 #           contains(github.event.review.user.login, 'copilot')) ||
 #         (github.event_name == 'pull_request_review_comment' &&
-#           contains(github.event.comment.body, '@claude')) ||
+#           contains(github.event.comment.body, '@claude') &&
+#           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+#                    github.event.comment.author_association)) ||
 #         (github.event_name == 'issue_comment' &&
-#           contains(github.event.comment.body, '@claude'))
+#           contains(github.event.comment.body, '@claude') &&
+#           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+#                    github.event.comment.author_association))
 #       permissions:
 #         contents: write
 #         pull-requests: write
@@ -47,8 +61,13 @@ on:
           Use '"*"' (quoted) to allow all bots. Empty string blocks all bots.
           Default is '"*"' because exact-match on
           'copilot-pull-request-reviewer[bot]' was observed to silently skip
-          in production (2026-04) — the workflow-level `if:` already guards
-          against non-Copilot bots with contains(..., 'copilot').
+          in production (2026-04). This input governs only the
+          claude-code-action's internal bot-author filter for comment-based
+          triggers — callers are expected to gate `pull_request_review` via
+          their own `if:` (e.g. `user.type == 'Bot'` +
+          `contains(login, 'copilot')`) and gate comment-based triggers
+          with an `author_association` check. See the example at the top
+          of this file.
         required: false
         type: string
         default: '*'

--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -16,9 +16,11 @@ name: 🤖 Claude Code
 #
 #   jobs:
 #     claude:
+#       # Permissive filter — exact-match on 'copilot-pull-request-reviewer[bot]'
+#       # was observed to silently skip in production (2026-04); use contains().
 #       if: >-
 #         (github.event_name == 'pull_request_review' &&
-#           github.event.review.user.login == 'copilot-pull-request-reviewer[bot]') ||
+#           contains(github.event.review.user.login, 'copilot')) ||
 #         (github.event_name == 'pull_request_review_comment' &&
 #           contains(github.event.comment.body, '@claude')) ||
 #         (github.event_name == 'issue_comment' &&
@@ -43,9 +45,13 @@ on:
         description: >-
           Comma-separated bot logins whose comments trigger Claude.
           Use '"*"' (quoted) to allow all bots. Empty string blocks all bots.
+          Default is '"*"' because exact-match on
+          'copilot-pull-request-reviewer[bot]' was observed to silently skip
+          in production (2026-04) — the workflow-level `if:` already guards
+          against non-Copilot bots with contains(..., 'copilot').
         required: false
         type: string
-        default: copilot-pull-request-reviewer[bot]
+        default: '*'
 
       timeout_minutes:
         description: Maximum minutes before the job is cancelled
@@ -70,6 +76,30 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      - name: Diagnose trigger
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REVIEW_USER: ${{ github.event.review.user.login }}
+          REVIEW_STATE: ${{ github.event.review.state }}
+          COMMENT_USER: ${{ github.event.comment.user.login }}
+          ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Claude Code trigger"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| event_name | \`${EVENT_NAME}\` |"
+            echo "| review.user.login | \`${REVIEW_USER}\` |"
+            echo "| review.state | \`${REVIEW_STATE}\` |"
+            echo "| comment.user.login | \`${COMMENT_USER}\` |"
+            echo "| actor | \`${ACTOR}\` |"
+            echo "| triggering_actor | \`${TRIGGERING_ACTOR}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Check author association
         if: >-
           github.event_name == 'issue_comment' &&


### PR DESCRIPTION
## Summary
Strict equality on `github.event.review.user.login == 'copilot-pull-request-reviewer[bot]'` was observed to silently skip every Copilot review on edilio PR #77, even though the REST API confirms the login matches that literal. Root cause unclear (payload drift or expression-engine quirk with `[bot]`); in either case, strict equality is the wrong shape of filter for this.

- Reusable-workflow example now uses `contains(..., 'copilot')`.
- Default `allowed_bots` changed to `*` so the claude-code-action's redundant internal filter doesn't also have to know the exact login string — the workflow-level `if:` gates on Copilot.
- Added an always-on `Diagnose trigger` step that writes \`event_name\`, \`review.user.login\`, \`review.state\`, \`comment.user.login\`, \`actor\`, \`triggering_actor\` to the run summary. Next time something is silently skipped we'll have evidence.

This unblocks edilio — once edilio switches from its inline copy to calling this reusable workflow at \`@v2\`, it gets the fix for free.

## Test plan
- [ ] After merge + \`v2\` retag, migrate edilio to call this reusable workflow (separate PR).
- [ ] Confirm the Diagnose step output appears in the run summary.
- [ ] Confirm Copilot review submissions trigger Claude fixes.