### PR TITLE
chore(ci): bootstrap org maintenance automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,51 +1,31 @@
----
+# Managed by navigaite/.github bootstrap. Do not edit manually —
+# changes will be overwritten the next time bootstrap-maintenance.sh runs.
+#
+# Rationale:
+# - github-actions ecosystem catches third-party action bumps.
+# - The reusable `navigaite/.github` pipeline is pinned via rolling `@v2` tag,
+#   which release-please retargets on every release. Do NOT let Dependabot
+#   SHA-pin it — that would cause noise PRs on every pipeline patch.
+# - Native package ecosystems (npm, pip, docker, etc.) add themselves via
+#   repo-specific overrides; the bootstrap script appends them based on
+#   files detected in the repo.
+
 version: 2
 updates:
-  # GitHub Actions dependencies
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
       day: monday
       time: '06:00'
+      timezone: Europe/Berlin
     open-pull-requests-limit: 5
-    labels:
-      - dependencies
-      - github-actions
-    commit-message:
-      prefix: 'chore(deps):'
-      include: scope
-    reviewers:
-      - navigaite/engineering
-
-  # Node.js dependencies
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-      time: '06:00'
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-      - javascript
-    commit-message:
-      prefix: 'chore(deps):'
-      include: scope
     groups:
-      # Group minor and patch updates
-      production-dependencies:
-        dependency-type: production
-        update-types:
-          - minor
-          - patch
-      development-dependencies:
-        dependency-type: development
-        update-types:
-          - minor
-          - patch
+      github-actions:
+        patterns: ['*']
     ignore:
-      # Ignore major version updates for stability
-      - dependency-name: '*'
-        update-types:
-          - version-update:semver-major
+      # Rolling major tag — never pin. Updates come from retagging in navigaite/.github.
+      - dependency-name: navigaite/.github/*
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/claude-code-fix.yaml
+++ b/.github/workflows/claude-code-fix.yaml
@@ -1,0 +1,47 @@
+# Managed by navigaite/.github bootstrap. Do not edit manually —
+# changes will be overwritten the next time bootstrap-maintenance.sh runs.
+---
+name: Claude Code
+
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude:
+    # Review branch: permissive `contains(login, 'copilot')` because exact-
+    # match on 'copilot-pull-request-reviewer[bot]' was observed to silently
+    # skip in production (2026-04). `user.type == 'Bot'` blocks human
+    # accounts whose login contains "copilot" from triggering.
+    #
+    # Comment branches: require `@claude` AND trusted author_association.
+    # The reusable workflow has a redundant step-level guard for
+    # issue_comment; repeating it here saves runner spin-ups and extends
+    # the check to pull_request_review_comment as well.
+    if: >-
+      (github.event_name == 'pull_request_review' &&
+        github.event.review.user.type == 'Bot' &&
+        contains(github.event.review.user.login, 'copilot')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                 github.event.comment.author_association)) ||
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                 github.event.comment.author_association))
+    uses: navigaite/.github/.github/workflows/claude-code.yaml@v2
+    secrets: inherit

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -1,186 +1,24 @@
+# Managed by navigaite/.github bootstrap. Do not edit manually —
+# changes will be overwritten the next time bootstrap-maintenance.sh runs.
+#
+# The cron minute/hour is staggered per repo to avoid a PR storm across
+# all Navigaite repos. Bootstrap script substitutes 0 5 * * 2 at install time.
 ---
-name: 🌲 Trunk Upgrade
-
-# Reusable workflow that runs `trunk upgrade` in the calling repo,
-# opens a PR with any resulting changes, and enables auto-merge via the
-# Navigaite workflow GitHub App. Consumer repos call this weekly.
-#
-# Example consumer workflow (.github/workflows/trunk-upgrade.yaml):
-#
-#   name: Trunk Upgrade
-#   on:
-#     schedule:
-#       - cron: '0 6 * * 1'   # bootstrap script staggers this per repo
-#     workflow_dispatch: {}
-#   permissions: {}
-#   jobs:
-#     upgrade:
-#       uses: navigaite/.github/.github/workflows/trunk-upgrade.yaml@v2
-#       secrets: inherit
+name: Trunk Upgrade
 
 on:
-  workflow_call:
-    inputs:
-      pr_branch:
-        description: Branch name used for the upgrade PR
-        required: false
-        type: string
-        default: chore/trunk-upgrade
-      pr_title:
-        description: Title for the upgrade PR
-        required: false
-        type: string
-        default: 'chore(deps): trunk upgrade'
-      base_branch:
-        description: Base branch to target. Defaults to the repo's default branch.
-        required: false
-        type: string
-        default: ''
-    secrets:
-      WORKFLOW_APP_ID:
-        description: Navigaite workflow App ID (optional, falls back to GITHUB_TOKEN)
-        required: false
-      WORKFLOW_APP_PRIVATE_KEY:
-        description: Navigaite workflow App private key (optional)
-        required: false
+  schedule:
+    - cron: '0 5 * * 2'
+  workflow_dispatch: {}
 
-permissions: {}
+# Caller-level permissions cap the reusable workflow's job permissions.
+# The called workflow needs contents+pull-requests write to push a branch
+# and open a PR with the upgrade diff.
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   upgrade:
-    name: 🌲 Trunk Upgrade
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Generate App token
-        id: app-token
-        if: env.HAS_APP == 'true'
-        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.4
-        with:
-          app-id: ${{ secrets.WORKFLOW_APP_ID }}
-          private-key: ${{ secrets.WORKFLOW_APP_PRIVATE_KEY }}
-        env:
-          HAS_APP: ${{ secrets.WORKFLOW_APP_ID != '' && secrets.WORKFLOW_APP_PRIVATE_KEY != '' }}
-
-      - name: Resolve token
-        id: token
-        shell: bash
-        env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
-          FALLBACK: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          if [[ -n "$APP_TOKEN" ]]; then
-            echo "value=$APP_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "using=app" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=$FALLBACK" >> "$GITHUB_OUTPUT"
-            echo "using=github-token" >> "$GITHUB_OUTPUT"
-            echo "::notice::WORKFLOW_APP_ID not set; using GITHUB_TOKEN. PRs will not auto-merge."
-          fi
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          token: ${{ steps.token.outputs.value }}
-          fetch-depth: 0
-
-      - name: Resolve base branch
-        id: base
-        shell: bash
-        env:
-          INPUT_BASE: ${{ inputs.base_branch }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: |
-          set -euo pipefail
-          if [[ -n "$INPUT_BASE" ]]; then
-            echo "name=$INPUT_BASE" >> "$GITHUB_OUTPUT"
-          else
-            echo "name=$DEFAULT_BRANCH" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Skip if PR already open
-        id: guard
-        shell: bash
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.value }}
-          BRANCH: ${{ inputs.pr_branch }}
-        run: |
-          set -euo pipefail
-          OPEN=$(gh pr list --head "$BRANCH" --state open --json number --jq 'length')
-          if [[ "$OPEN" != "0" ]]; then
-            echo "::notice::An open PR already exists on $BRANCH; skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Skip if no .trunk/trunk.yaml
-        if: steps.guard.outputs.skip == 'false'
-        id: trunk-present
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ ! -f ".trunk/trunk.yaml" ]]; then
-            echo "::notice::No .trunk/trunk.yaml; nothing to upgrade."
-            echo "present=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Install Trunk
-        if: steps.guard.outputs.skip == 'false' && steps.trunk-present.outputs.present == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          curl -fsSL https://trunk.io/releases/trunk -o /usr/local/bin/trunk
-          chmod +x /usr/local/bin/trunk
-          trunk --version
-
-      - name: Run trunk upgrade
-        if: steps.guard.outputs.skip == 'false' && steps.trunk-present.outputs.present == 'true'
-        id: upgrade
-        shell: bash
-        run: |
-          set -euo pipefail
-          trunk upgrade --ci
-          if git diff --quiet; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Trunk is already up to date."
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "::group::Trunk upgrade diff"
-            git diff --stat
-            echo "::endgroup::"
-          fi
-
-      - name: Create Pull Request
-        if: steps.upgrade.outputs.changed == 'true'
-        id: cpr
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
-        with:
-          token: ${{ steps.token.outputs.value }}
-          branch: ${{ inputs.pr_branch }}
-          base: ${{ steps.base.outputs.name }}
-          commit-message: ${{ inputs.pr_title }}
-          title: ${{ inputs.pr_title }}
-          body: |
-            Automated `trunk upgrade` run.
-
-            Produced by [`navigaite/.github` trunk-upgrade workflow](https://github.com/navigaite/.github/blob/main/.github/workflows/trunk-upgrade.yaml).
-            Auto-merges after `Check Gate` passes.
-          delete-branch: true
-          signoff: true
-
-      - name: Enable auto-merge
-        if: steps.cpr.outputs.pull-request-number != '' && steps.token.outputs.using == 'app'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.value }}
-          PR: ${{ steps.cpr.outputs.pull-request-number }}
-        run: |
-          set -euo pipefail
-          gh pr merge "$PR" --squash --auto
-          echo "::notice::Auto-merge enabled on PR #$PR"
+    uses: navigaite/.github/.github/workflows/trunk-upgrade.yaml@v2
+    secrets: inherit


### PR DESCRIPTION
Automated bootstrap from `navigaite/.github`. Installs:

- Weekly Dependabot updates (github-actions ecosystem).
- Staggered `trunk upgrade` workflow that auto-merges after CI.
- Thin `Claude Code Fix` caller at `.github/workflows/claude-code-fix.yaml` that delegates to the reusable workflow in `navigaite/.github`. Removes any legacy inline `.github/workflows/claude-code.yaml`.

Managed by `scripts/bootstrap-maintenance.sh` — edits to these files will be overwritten on the next bootstrap run.