### PR TITLE
chore(ci): bootstrap org maintenance automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,51 +1,31 @@
----
+# Managed by navigaite/.github bootstrap. Do not edit manually —
+# changes will be overwritten the next time bootstrap-maintenance.sh runs.
+#
+# Rationale:
+# - github-actions ecosystem catches third-party action bumps.
+# - The reusable `navigaite/.github` pipeline is pinned via rolling `@v2` tag,
+#   which release-please retargets on every release. Do NOT let Dependabot
+#   SHA-pin it — that would cause noise PRs on every pipeline patch.
+# - Native package ecosystems (npm, pip, docker, etc.) add themselves via
+#   repo-specific overrides; the bootstrap script appends them based on
+#   files detected in the repo.
+
 version: 2
 updates:
-  # GitHub Actions dependencies
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
       day: monday
       time: '06:00'
+      timezone: Europe/Berlin
     open-pull-requests-limit: 5
-    labels:
-      - dependencies
-      - github-actions
-    commit-message:
-      prefix: 'chore(deps):'
-      include: scope
-    reviewers:
-      - navigaite/engineering
-
-  # Node.js dependencies
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-      time: '06:00'
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-      - javascript
-    commit-message:
-      prefix: 'chore(deps):'
-      include: scope
     groups:
-      # Group minor and patch updates
-      production-dependencies:
-        dependency-type: production
-        update-types:
-          - minor
-          - patch
-      development-dependencies:
-        dependency-type: development
-        update-types:
-          - minor
-          - patch
+      github-actions:
+        patterns: ['*']
     ignore:
-      # Ignore major version updates for stability
-      - dependency-name: '*'
-        update-types:
-          - version-update:semver-major
+      # Rolling major tag — never pin. Updates come from retagging in navigaite/.github.
+      - dependency-name: navigaite/.github/*
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/claude-code-fix.yaml
+++ b/.github/workflows/claude-code-fix.yaml
@@ -1,0 +1,47 @@
+# Managed by navigaite/.github bootstrap. Do not edit manually —
+# changes will be overwritten the next time bootstrap-maintenance.sh runs.
+---
+name: Claude Code Fix
+
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude:
+    # Review branch: permissive `contains(login, 'copilot')` because exact-
+    # match on 'copilot-pull-request-reviewer[bot]' was observed to silently
+    # skip in production (2026-04). `user.type == 'Bot'` blocks human
+    # accounts whose login contains "copilot" from triggering.
+    #
+    # Comment branches: require `@claude` AND trusted author_association.
+    # The reusable workflow has a redundant step-level guard for
+    # issue_comment; repeating it here saves runner spin-ups and extends
+    # the check to pull_request_review_comment as well.
+    if: >-
+      (github.event_name == 'pull_request_review' &&
+        github.event.review.user.type == 'Bot' &&
+        contains(github.event.review.user.login, 'copilot')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                 github.event.comment.author_association)) ||
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                 github.event.comment.author_association))
+    uses: navigaite/.github/.github/workflows/claude-code.yaml@v2
+    secrets: inherit

--- a/.github/workflows/trunk-upgrade-scheduled.yaml
+++ b/.github/workflows/trunk-upgrade-scheduled.yaml
@@ -1,0 +1,24 @@
+# Managed by navigaite/.github bootstrap. Do not edit manually —
+# changes will be overwritten the next time bootstrap-maintenance.sh runs.
+#
+# The cron minute/hour is staggered per repo to avoid a PR storm across
+# all Navigaite repos. Bootstrap script substitutes 0 5 * * 2 at install time.
+---
+name: Trunk Upgrade Scheduled
+
+on:
+  schedule:
+    - cron: '0 5 * * 2'
+  workflow_dispatch: {}
+
+# Caller-level permissions cap the reusable workflow's job permissions.
+# The called workflow needs contents+pull-requests write to push a branch
+# and open a PR with the upgrade diff.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  upgrade:
+    uses: navigaite/.github/.github/workflows/trunk-upgrade.yaml@v2
+    secrets: inherit


### PR DESCRIPTION
Automated bootstrap from `navigaite/.github`. Installs:

- Weekly Dependabot updates (github-actions ecosystem).
- Staggered `Trunk Upgrade Scheduled` caller at `.github/workflows/trunk-upgrade-scheduled.yaml` that delegates to the reusable `trunk-upgrade` workflow in `navigaite/.github`. Auto-merges after CI.
- Thin `Claude Code Fix` caller at `.github/workflows/claude-code-fix.yaml` that delegates to the reusable `claude-code` workflow in `navigaite/.github`.

If this repo previously had caller-style `trunk-upgrade.yaml` or `claude-code.yaml` at those shared paths, they are removed here in favor of the new `-fix` / `-scheduled` naming. Reusable-workflow definitions (files with `on: workflow_call`) are preserved.

Managed by `scripts/bootstrap-maintenance.sh` — edits to these files will be overwritten on the next bootstrap run.