### PR TITLE
review(templates): PR-only issue_comment guard + permission convention

### DIFF
--- a/.github/config/templates/claude-code-fix.yaml
+++ b/.github/config/templates/claude-code-fix.yaml
@@ -15,13 +15,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+permissions: {}
 
 jobs:
   claude:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     # Review branch: permissive `contains(login, 'copilot')` because exact-
     # match on 'copilot-pull-request-reviewer[bot]' was observed to silently
     # skip in production (2026-04). `user.type == 'Bot'` blocks human
@@ -40,6 +41,7 @@ jobs:
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
                  github.event.comment.author_association)) ||
       (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
         contains(github.event.comment.body, '@claude') &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
                  github.event.comment.author_association))

--- a/.github/config/templates/trunk-upgrade-scheduled.yaml
+++ b/.github/config/templates/trunk-upgrade-scheduled.yaml
@@ -11,14 +11,15 @@ on:
     - cron: '__CRON__'
   workflow_dispatch: {}
 
-# Caller-level permissions cap the reusable workflow's job permissions.
-# The called workflow needs contents+pull-requests write to push a branch
-# and open a PR with the upgrade diff.
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   upgrade:
+    # Job-level permissions cap the reusable workflow's job permissions.
+    # The called workflow needs contents+pull-requests write to push a
+    # branch and open a PR with the upgrade diff.
+    permissions:
+      contents: write
+      pull-requests: write
     uses: navigaite/.github/.github/workflows/trunk-upgrade.yaml@v2
     secrets: inherit

--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -36,6 +36,7 @@ name: 🤖 Claude Code
 #           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
 #                    github.event.comment.author_association)) ||
 #         (github.event_name == 'issue_comment' &&
+#           github.event.issue.pull_request &&
 #           contains(github.event.comment.body, '@claude') &&
 #           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
 #                    github.event.comment.author_association))


### PR DESCRIPTION
## Summary
Addresses Copilot feedback on #81:

- **claude-code-fix.yaml** `issue_comment` branch: add \`github.event.issue.pull_request\` guard so \`@claude\` comments on non-PR issues don't spin up the reusable workflow (the reusable workflow's checkout fallback expects a PR context).
- **claude-code-fix.yaml + trunk-upgrade-scheduled.yaml**: move \`permissions\` from workflow-root to job-level, with workflow-level \`permissions: {}\`. Matches the repo convention in \`ci.yaml\` / \`release.yaml\` and keeps the permission grant scoped to the single delegating job.
- Reusable \`claude-code.yaml\` example docstring updated to mirror the guard.

## Rollout
Supersedes the current pilot PRs (#80 edilio, #81 .github) which carried the older template content. Close those first, then after this merges + v2 retags, re-run the bootstrap.