### PR TITLE
fix(claude-code): grant id-token: write for OIDC

### DIFF
--- a/.github/config/templates/claude-code-fix.yaml
+++ b/.github/config/templates/claude-code-fix.yaml
@@ -23,6 +23,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write          # required for claude-code-action OIDC token
     # Review branch: permissive `contains(login, 'copilot')` because exact-
     # match on 'copilot-pull-request-reviewer[bot]' was observed to silently
     # skip in production (2026-04). `user.type == 'Bot'` blocks human

--- a/.github/workflows/claude-code-fix.yaml
+++ b/.github/workflows/claude-code-fix.yaml
@@ -23,6 +23,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write          # required for claude-code-action OIDC token
     # Review branch: permissive `contains(login, 'copilot')` because exact-
     # match on 'copilot-pull-request-reviewer[bot]' was observed to silently
     # skip in production (2026-04). `user.type == 'Bot'` blocks human

--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -44,6 +44,7 @@ name: 🤖 Claude Code
 #         contents: write
 #         pull-requests: write
 #         issues: write
+#         id-token: write          # required for claude-code-action OIDC
 #       uses: navigaite/.github/.github/workflows/claude-code.yaml@main
 #       secrets: inherit
 
@@ -95,6 +96,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write          # required: claude-code-action fetches an OIDC token
     steps:
       - name: Diagnose trigger
         shell: bash

--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -45,7 +45,7 @@ name: 🤖 Claude Code
 #         pull-requests: write
 #         issues: write
 #         id-token: write          # required for claude-code-action OIDC
-#       uses: navigaite/.github/.github/workflows/claude-code.yaml@main
+#       uses: navigaite/.github/.github/workflows/claude-code.yaml@v2
 #       secrets: inherit
 
 on:


### PR DESCRIPTION
The `anthropics/claude-code-action` fetches an OIDC token via \`ACTIONS_ID_TOKEN_REQUEST_URL\`, which requires \`id-token: write\` at the job permission level.

Without it the action fails with:

\`\`\`
Could not fetch an OIDC token. Did you remember to add \`id-token: write\` to your workflow permissions?
\`\`\`

Observed on [navigaite/edilio#81](https://github.com/navigaite/edilio/pull/81), job [71406249360](https://github.com/navigaite/edilio/actions/runs/24441150524/job/71406249360).

## Changes

1. **Reusable workflow** \`.github/workflows/claude-code.yaml\` — adds \`id-token: write\` to the job's \`permissions:\` block.
2. **Caller template** \`.github/config/templates/claude-code-fix.yaml\` — same addition, because caller-level job permissions cap the reusable workflow's effective permissions (both must grant it).
3. **Inline caller example** in the reusable workflow's docstring — mirrors the template for hand-wired setups.

## Follow-up

After this merges, the open bootstrap PRs (15 of them) need their \`claude-code-fix.yaml\` re-pushed from the updated template. I'll do that as a separate pass so each PR carries the fix.