### PR TITLE
fix(claude-code): whitelist Copilot for bot-triggered permission check

### DIFF
--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -202,3 +202,17 @@ jobs:
               && (steps.app-token.outputs.token || secrets.GITHUB_TOKEN)
               || ''
             }}
+          # claude-code-action's checkWritePermissions auto-allows actors
+          # whose login ends with `[bot]`, but Copilot PR reviews run as
+          # `github.actor == 'Copilot'` (no suffix) and the subsequent
+          # `getCollaboratorPermissionLevel` call 404s with "Copilot is not
+          # a user". Whitelist Copilot for bot-triggered runs only; human
+          # triggers keep the default (empty) so the normal write-permission
+          # check still applies. Requires `github_token` to be set — see
+          # claude-code-action src/github/validation/permissions.ts.
+          allowed_non_write_users: >-
+            ${{
+              github.event.review.user.type == 'Bot'
+              && 'Copilot'
+              || ''
+            }}


### PR DESCRIPTION
## Summary

- Second half of the Copilot-PR-review fix. After #92 bypassed the OIDC app-token exchange, `claude-code-action`'s `checkWritePermissions` still failed with `Failed to check permissions: HttpError: Copilot is not a user` — the auto-allow path only matches actors ending in `[bot]`, but Copilot's `github.actor` is plain `Copilot`. `getCollaboratorPermissionLevel` then 404s because Copilot isn't a real GitHub user.
- Fix: pass `allowed_non_write_users: 'Copilot'` on bot-triggered runs to take the documented bypass path in [`src/github/validation/permissions.ts`](https://github.com/anthropics/claude-code-action/blob/main/src/github/validation/permissions.ts) (which requires `github_token`, which #92 already provides). Human triggers keep the input empty so the normal write-permission check still applies.

## Observed failure

navigaite/edilio run [24458461551](https://github.com/navigaite/edilio/actions/runs/24458461551) (PR #86, Copilot review trigger) — fired against #92 but failed at the permission check.

## Test plan

- [ ] Merge, move `v2` tag, trigger a fresh Copilot review on a consumer PR, confirm Claude Code Fix completes without permission errors
- [ ] Verify human `@claude` mentions still require write access (input resolves to empty → normal check runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)