### PR TITLE
fix(claude-code): add auto-prompt so bot-triggered runs actually do work

### DIFF
--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -216,3 +216,19 @@ jobs:
               && 'Copilot'
               || ''
             }}
+          # Without a `prompt`, claude-code-action only runs when someone
+          # mentions the trigger phrase (`@claude`) in a comment. Bot PR
+          # reviews don't include mentions, so the action would log "No
+          # trigger was met for @claude" and exit. Provide an explicit
+          # prompt on bot-triggered runs so Claude addresses the review
+          # automatically. Human triggers keep prompt empty and continue
+          # using the normal `@claude` mention flow.
+          prompt: >-
+            ${{
+              github.event.review.user.type == 'Bot'
+              && format(
+                'A bot reviewer ({0}) submitted a review on this pull request. Read the full review and every inline comment, then for each actionable piece of feedback either (a) apply the fix as a commit on the PR branch or (b) reply to the thread explaining why you are not applying it. Resolve the review threads you have addressed. When you are done, post a single summary comment listing what you changed and what you left.',
+                github.event.review.user.login
+              )
+              || ''
+            }}


### PR DESCRIPTION
## Summary

Completes the Copilot PR review pipeline. After #92 (OIDC→app-token bypass) and #94 (`allowed_non_write_users: 'Copilot'`), `claude-code-action` is now reached successfully on bot-triggered runs — but it immediately logs:

\`\`\`
No trigger was met for @claude
Context prompt: NO PROMPT
No trigger found, skipping remaining steps
\`\`\`

…and exits without doing anything, because bot PR reviews don't include a \`@claude\` mention (the default trigger phrase). The workflow conclusion is \"success\" but no fixes are made.

**Observed**: navigaite/edilio run [24471760116](https://github.com/navigaite/edilio/actions/runs/24471760116) — green, 0 work performed.

## Fix

Pass a \`prompt\` on bot-triggered runs only, telling Claude to address the review. Human-triggered runs keep prompt empty and continue to use the \`@claude\` mention flow.

## Test plan

- [ ] Merge, move \`v2\` tag, trigger a fresh Copilot review on any consumer PR → Claude should read the review, commit fixes or reply per thread, and post a summary
- [ ] Verify human PRs without \`@claude\` still no-op (prompt resolves to empty → normal trigger-phrase detection)
- [ ] Verify human \`@claude\` mentions still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)