### PR TITLE
fix(claude-code): shrink repost comment, queue instead of cancel

### DIFF
--- a/.github/config/templates/claude-code-fix.yaml
+++ b/.github/config/templates/claude-code-fix.yaml
@@ -11,9 +11,14 @@ on:
   issue_comment:
     types: [created]
 
+# Queue, don't cancel. Claude runs make code changes and post review
+# replies — cancelling them mid-flight leaves the action's "eyes"
+# reaction stuck in a pending state and wastes the partial work. GitHub
+# auto-coalesces further events into the queued slot, so rapid-fire
+# reviews collapse to one pending run without stranded indicators.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions: {}
 

--- a/.github/workflows/claude-code-fix.yaml
+++ b/.github/workflows/claude-code-fix.yaml
@@ -11,9 +11,14 @@ on:
   issue_comment:
     types: [created]
 
+# Queue, don't cancel. Claude runs make code changes and post review
+# replies — cancelling them mid-flight leaves the action's "eyes"
+# reaction stuck in a pending state and wastes the partial work. GitHub
+# auto-coalesces further events into the queued slot, so rapid-fire
+# reviews collapse to one pending run without stranded indicators.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions: {}
 

--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -151,24 +151,19 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
-          REVIEW_ID: ${{ github.event.review.id }}
           REVIEW_USER: ${{ github.event.review.user.login }}
-          REVIEW_BODY: ${{ github.event.review.body }}
           REVIEW_URL: ${{ github.event.review.html_url }}
         run: |
           set -euo pipefail
 
-          # shellcheck disable=SC2016  # jq filter, not shell expansion
-          inline="$(gh api "repos/${REPO}/pulls/${PR}/reviews/${REVIEW_ID}/comments" \
-            --jq '[.[] | "- **`" + .path + (if .line then ":" + (.line|tostring) else "" end) + "`** — " + .body] | join("\n\n")' \
-            || echo "")"
-
+          # Minimal trigger comment — Claude has gh/GitHub MCP access and
+          # can fetch the review body and inline comments itself. Dumping
+          # them into the comment body just duplicates content that lives
+          # one click away on the same PR.
           jq -n \
             --arg user "$REVIEW_USER" \
-            --arg rb "${REVIEW_BODY:-_(no summary provided)_}" \
-            --arg inline "${inline:-_(no inline comments)_}" \
             --arg url "$REVIEW_URL" \
-            '{body: ("@claude A code reviewer (**" + $user + "**) submitted a review on this PR. Please address valid suggestions by making code changes, and reply to any inline comment where the suggestion does not apply, explaining why.\n\n**Summary**\n\n" + $rb + "\n\n**Inline comments**\n\n" + $inline + "\n\n_[Original review](" + $url + ")_")}' \
+            '{body: ("@claude **" + $user + "** [submitted a review](" + $url + "). Please fetch the review + inline comments, address valid suggestions, and reply to any that do not apply.")}' \
             | gh api "repos/${REPO}/issues/${PR}/comments" --input -
 
           echo "::notice::Reposted Copilot review from ${REVIEW_USER} as @claude comment on PR #${PR}."


### PR DESCRIPTION
## Summary
Two problems observed on [edilio#102](https://github.com/navigaite/edilio/pull/102):

1. The \`@claude\` trigger comment posted by \`repost-copilot-review\` inlined the entire Copilot review body plus every inline comment — duplicating content that already lives one click away on the same PR. Replaced with a minimal pointer (\`@claude <user> [submitted a review](url). Please fetch the review + inline comments, address valid suggestions, and reply to any that do not apply.\`). Claude has \`gh\` and GitHub MCP access and can fetch the detail itself.

2. \`cancel-in-progress: true\` killed in-flight Claude runs when a new review/comment arrived. The claude-code-action's \`eyes\` reaction stayed stuck in a pending state (since the action never got to finalize), and any partial edits / replies were discarded. Switched to \`cancel-in-progress: false\` so rapid-fire events queue and collapse onto one pending slot — GitHub only keeps one pending + one running per group.

Updated in three places so they stay in sync:
- \`.github/workflows/claude-code.yaml\` — the reusable workflow's repost step (comment body)
- \`.github/workflows/claude-code-fix.yaml\` — local caller (concurrency)
- \`.github/config/templates/claude-code-fix.yaml\` — template synced out to consumer repos by \`bootstrap-maintenance.sh\` (concurrency)

## Test plan
- [ ] Merge → release-please cuts v2.x.y → consumer repos on \`@v2\` pick up the reusable workflow fix immediately.
- [ ] Next \`bootstrap-maintenance.sh\` run propagates the concurrency change to consumer callers.
- [ ] Next Copilot review on any PR: trigger comment is one sentence, Claude fetches the review on its own.
- [ ] Rapid-fire commits/reviews: no stuck "pending" eyes reactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)