### PR TITLE
chore(claude-code-fix): remove automatic Copilot-triggered Claude run

### DIFF
--- a/.github/config/templates/claude-code-fix.yaml
+++ b/.github/config/templates/claude-code-fix.yaml
@@ -4,8 +4,6 @@
 name: Claude Code Fix
 
 on:
-  pull_request_review:
-    types: [submitted]
   pull_request_review_comment:
     types: [created]
   issue_comment:
@@ -29,21 +27,10 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write          # required for claude-code-action OIDC token
-    # Review branch: permissive `contains(login, 'copilot')` because exact-
-    # match on 'copilot-pull-request-reviewer[bot]' was observed to silently
-    # skip in production (2026-04). `user.type == 'Bot'` blocks human
-    # accounts whose login contains "copilot" from triggering.
-    #
-    # Comment branches: require `@claude` AND trusted author_association.
-    # The `navigaite-workflow-app[bot]` OR-branch admits synthesized
-    # `@claude` comments posted by the reusable workflow's own
-    # `repost-copilot-review` job — that's how Copilot reviews are
-    # handled, since claude-code-action@v1 `checkHumanActor` 404s on
-    # `users.getByUsername('Copilot')`.
+    # Manual on-demand only: require `@claude` in the comment body and a
+    # trusted author_association. Automatic Copilot → Claude auto-fix
+    # was removed.
     if: >-
-      (github.event_name == 'pull_request_review' &&
-        github.event.review.user.type == 'Bot' &&
-        contains(github.event.review.user.login, 'copilot')) ||
       (github.event_name == 'pull_request_review_comment' &&
         contains(github.event.comment.body, '@claude') &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
@@ -51,8 +38,7 @@ jobs:
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         contains(github.event.comment.body, '@claude') &&
-        (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-                  github.event.comment.author_association) ||
-         github.event.comment.user.login == 'navigaite-workflow-app[bot]'))
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                 github.event.comment.author_association))
     uses: navigaite/.github/.github/workflows/claude-code.yaml@v2
     secrets: inherit

--- a/.github/workflows/claude-code-fix.yaml
+++ b/.github/workflows/claude-code-fix.yaml
@@ -4,8 +4,6 @@
 name: Claude Code Fix
 
 on:
-  pull_request_review:
-    types: [submitted]
   pull_request_review_comment:
     types: [created]
   issue_comment:
@@ -29,21 +27,10 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write          # required for claude-code-action OIDC token
-    # Review branch: permissive `contains(login, 'copilot')` because exact-
-    # match on 'copilot-pull-request-reviewer[bot]' was observed to silently
-    # skip in production (2026-04). `user.type == 'Bot'` blocks human
-    # accounts whose login contains "copilot" from triggering.
-    #
-    # Comment branches: require `@claude` AND trusted author_association.
-    # The `navigaite-workflow-app[bot]` OR-branch admits synthesized
-    # `@claude` comments posted by the reusable workflow's own
-    # `repost-copilot-review` job — that's how Copilot reviews are
-    # handled, since claude-code-action@v1 `checkHumanActor` 404s on
-    # `users.getByUsername('Copilot')`.
+    # Manual on-demand only: require `@claude` in the comment body and a
+    # trusted author_association. Automatic Copilot → Claude auto-fix
+    # was removed.
     if: >-
-      (github.event_name == 'pull_request_review' &&
-        github.event.review.user.type == 'Bot' &&
-        contains(github.event.review.user.login, 'copilot')) ||
       (github.event_name == 'pull_request_review_comment' &&
         contains(github.event.comment.body, '@claude') &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
@@ -51,8 +38,7 @@ jobs:
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         contains(github.event.comment.body, '@claude') &&
-        (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-                  github.event.comment.author_association) ||
-         github.event.comment.user.login == 'navigaite-workflow-app[bot]'))
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                 github.event.comment.author_association))
     uses: navigaite/.github/.github/workflows/claude-code.yaml@v2
     secrets: inherit


### PR DESCRIPTION
## Summary

- Remove the `pull_request_review` trigger and its Copilot bot-review branch from the `Claude Code Fix` workflow in both the reusable-workflow caller and the consumer template.
- Drop the `navigaite-workflow-app[bot]` OR-branch on `issue_comment`; it only existed to admit the synthesized `@claude` comments from `repost-copilot-review`, which can no longer fire.

After this lands, `Claude Code Fix` only runs on explicit `@claude` mentions in PR review comments and PR/issue comments from trusted author_associations. The reusable `claude-code.yaml` still contains `repost-copilot-review` and the `checkHumanActor` bypass for `pull_request_review`; those paths are now unreachable from Navigaite consumers and can be cleaned up in a follow-up.

A companion PR in `navigaite/edilio` syncs the regenerated workflow.

## Test plan

- [ ] Consumer repo: verify `pull_request_review` from Copilot no longer queues a `Claude Code Fix` run.
- [ ] Consumer repo: verify `@claude` in a PR review comment / issue comment still triggers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)