### PR TITLE
perf(ci): drop redundant global pnpm install

### DIFF
--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -103,6 +103,11 @@ runs:
                 ;;
               pnpm)
                 # pnpm is pre-installed by pnpm/action-setup in setup-environment
+                if ! command -v pnpm >/dev/null 2>&1; then
+                  echo "::error::pnpm is not installed. Run the setup-environment action" \
+                    "before install-dependencies, or install pnpm via pnpm/action-setup."
+                  exit 1
+                fi
                 echo "Installing with pnpm install --frozen-lockfile..."
                 pnpm install --frozen-lockfile
                 ;;

--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -102,8 +102,7 @@ runs:
                 done
                 ;;
               pnpm)
-                echo "Installing pnpm globally..."
-                npm install -g pnpm
+                # pnpm is pre-installed by pnpm/action-setup in setup-environment
                 echo "Installing with pnpm install --frozen-lockfile..."
                 pnpm install --frozen-lockfile
                 ;;

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -128,7 +128,7 @@ permissions: {}
 
 concurrency:
   group: ${{ github.repository }}-pipeline-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # =============================================================================

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -128,7 +128,7 @@ permissions: {}
 
 concurrency:
   group: ${{ github.repository }}-pipeline-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 jobs:
   # =============================================================================


### PR DESCRIPTION
## Summary

Single focused P0 win from the org-wide CI/CD audit:

- **`perf(ci)`** Drop the redundant `npm install -g pnpm` inside `install-dependencies`. `setup-environment` already installs pnpm via `pnpm/action-setup` earlier in the pipeline — the duplicate install added 10–20s per Node.js run and occasionally conflicted with the toolchain cache.
- **`fix(ci)`** Add a `command -v pnpm` guard so callers using `install-dependencies` standalone get a clear error pointing them at `pnpm/action-setup` instead of a cryptic "command not found". (Addresses Copilot review feedback.)

## What changed vs. initial PR

The original PR also bundled a `cancel-in-progress` "fix" for the `dev` branch, but Copilot correctly flagged that the original expression `github.ref != 'refs/heads/main'` already evaluated to `true` on `dev` — dev was already cancelling in-flight runs. My change inverted that and would have *disabled* cancellation on dev. Reverted in ad603a4; the audit's claim that dev wasn't being cancelled was wrong.

## Impact

- Every Node.js pipeline run shortens by ~10–20s across every Node consumer in the org.
- Standalone users of `install-dependencies` now fail fast with an actionable error instead of a bare "pnpm: command not found".

## Out of scope (tracked for follow-up PRs)

From the same audit but deferred because they need more thought / larger blast radius:

- Collapse `lint` + `test` + `build` into one job to share a single checkout + dependency install.
- Pass the built artifact to `deploy-docker` instead of rebuilding from scratch.
- Re-evaluate `nightly-maintenance` cadence and per-repo scope (6+ repos currently call it via `workflow_call`; changes here ripple org-wide).

## Test plan

- [ ] `ci.yaml` in this repo still passes (composite action validation + actionlint)
- [ ] Smoke-test against edilio on `dev` — confirm pipeline still runs end-to-end and pnpm install still succeeds
- [ ] Confirm a standalone caller of `install-dependencies` without `setup-environment` now fails with the new guard message

🤖 Generated with [Claude Code](https://claude.com/claude-code)