### PR TITLE
perf(ci): cache turborepo outputs across runs

### DIFF
--- a/.github/actions/run-build/action.yaml
+++ b/.github/actions/run-build/action.yaml
@@ -62,6 +62,33 @@ runs:
           echo "::error::Invalid working-directory '$WORKING_DIR'. Must be a relative path without '..'"; exit 1
         fi
 
+    - name: Detect Turborepo
+      id: detect-turbo
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        if [[ -f turbo.json ]] || [[ -f turbo.jsonc ]]; then
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          echo "Detected turbo.json — turbo cache will be restored/saved across runs."
+        else
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Restore Turbo Cache
+      if: steps.detect-turbo.outputs.enabled == 'true'
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ inputs.working-directory }}/node_modules/.cache/turbo
+        key: turbo-build-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+        restore-keys: |
+          turbo-build-${{ runner.os }}-${{ github.ref_name }}-
+          turbo-tests-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+          turbo-tests-${{ runner.os }}-${{ github.ref_name }}-
+          turbo-build-${{ runner.os }}-
+          turbo-tests-${{ runner.os }}-
+          turbo-${{ runner.os }}-
+
     - name: Run Build
       id: build
       shell: bash
@@ -124,6 +151,13 @@ runs:
 
         echo "✅ Build completed successfully"
         echo "::endgroup::"
+
+    - name: Save Turbo Cache
+      if: always() && steps.detect-turbo.outputs.enabled == 'true'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ inputs.working-directory }}/node_modules/.cache/turbo
+        key: turbo-build-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
 
     - name: Detect Build Output
       if: inputs.upload-artifacts == 'true' && inputs.artifact-path == ''

--- a/.github/actions/run-tests/action.yaml
+++ b/.github/actions/run-tests/action.yaml
@@ -42,6 +42,30 @@ runs:
           echo "::error::Invalid working-directory '$WORKING_DIR'. Must be a relative path without '..'"; exit 1
         fi
 
+    - name: Detect Turborepo
+      id: detect-turbo
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        if [[ -f turbo.json ]] || [[ -f turbo.jsonc ]]; then
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          echo "Detected turbo.json — turbo cache will be restored/saved across runs."
+        else
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Restore Turbo Cache
+      if: steps.detect-turbo.outputs.enabled == 'true'
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ inputs.working-directory }}/node_modules/.cache/turbo
+        key: turbo-tests-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+        restore-keys: |
+          turbo-tests-${{ runner.os }}-${{ github.ref_name }}-
+          turbo-tests-${{ runner.os }}-
+          turbo-${{ runner.os }}-
+
     - name: Run Tests
       id: test
       shell: bash
@@ -214,6 +238,13 @@ runs:
 
         echo "::endgroup::"
         exit "${TEST_EXIT_CODE:-0}"
+
+    - name: Save Turbo Cache
+      if: always() && steps.detect-turbo.outputs.enabled == 'true'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ inputs.working-directory }}/node_modules/.cache/turbo
+        key: turbo-tests-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
 
     - name: Upload Coverage
       id: detect-coverage


### PR DESCRIPTION
## Summary

Turborepo's local cache (`node_modules/.cache/turbo`) is wiped with every ephemeral GitHub runner, so CI shows `Cached: 0 cached, 17 total` on every single run — Edilio rebuilds the full TypeScript project graph from scratch on every PR and push.

Add GHA-backed restore/save around the Run Tests and Run Build steps in the shared composite actions. Auto-enabled when `turbo.json` (or `turbo.jsonc`) is detected in the working directory; transparent for non-turbo consumers (the steps skip entirely).

## Why this targets both jobs

Edilio Test job log breakdown (latest PR run):

| step | wall-clock |
|---|---|
| Install Dependencies | 27s |
| **Run Tests (type-check + test)** | **193s** |
| └─ `turbo run type-check` | 128s (17 tasks, 0 cached) |
| └─ `turbo run test` | 64s (12 tasks, 0 cached) |

Build runs `turbo run build` on a different runner, so it hits the same cold-cache problem. Caching both jobs means Build can also pick up state from Test within the same pipeline run via the `restore-keys` chain.

## Cache key strategy

- **Write key** (scoped per job + branch + commit): `turbo-<tests|build>-<os>-<ref>-<sha>`
- **Restore fallback chain:**
  1. Same job scope, same branch, older commit
  2. Other job scope, same commit (lets Test + Build share within a run)
  3. Other job scope, same branch, older commit
  4. Same job scope, any branch (cross-branch fallback)
  5. Other job scope, any branch
  6. Any branch (widest fallback)

This way feature branches inherit from `main`/`dev`, and job pairs share state within one pipeline invocation.

## Expected impact

For Edilio (26+ pipeline runs/month):
- **First run on a new branch:** unchanged (cold cache from widest fallback)
- **Subsequent runs, unchanged packages:** type-check drops from 128s → ~5–15s (turbo verifies hashes + restores outputs). Tests where all deps are cache hits drop from 64s to ~20–30s
- **Partial changes:** proportional cache hits

Conservative estimate: **1–2 min wall-clock saved per run after the first** → 25–50 min/month on Edilio alone, plus similar wins for any other turbo consumer (e.g. `maimaldrei-mietkatalog`).

## Safety

- Zero behavior change for non-turbo repos (steps skipped via `if:`).
- Uses `actions/cache@v5.0.5` split restore/save pattern (official, SHA-pinned).
- Save is `always()` so partial cache state (e.g. type-check ran, tests failed) still persists for next run.
- Cache path is working-directory-relative, respecting the existing path-traversal guards.

## Test plan

- [ ] `ci.yaml` still passes (actionlint + path-traversal tests)
- [ ] Cut a pre-release and smoke-test against Edilio on a feature branch — verify:
  - [ ] First run: logs show `Cache not found` (expected cold start)
  - [ ] Second run on same branch: logs show `Cache restored` and turbo reports `Cached: N cached, N total`
  - [ ] Test job duration drops by ~1–2 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)