### PR TITLE
feat(ci): skip test/build/deploy on docs-only PRs

### DIFF
--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -140,7 +140,11 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      pull-requests: read # for docs-only change detection via PR files API
     outputs:
+      # Change classification
+      docs-only: ${{ steps.docs-check.outputs.docs-only }}
+
       # Tech stack detection
       stack: ${{ steps.setup-env.outputs.detected-stack }}
       runtime-version: ${{ steps.setup-env.outputs.runtime-version }}
@@ -459,6 +463,57 @@ jobs:
           write-summary: 'false'
           enable-caching: 'false'
 
+      - name: 📄 Detect Docs-Only Changes
+        id: docs-check
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Only classify docs-only for pull_request events. push events (merge to main/dev)
+          # always run the full pipeline so deploy/release don't get silently skipped.
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "docs-only=false" >> "$GITHUB_OUTPUT"
+            echo "Event '$EVENT_NAME' — docs-only detection only applies to pull_request."
+            exit 0
+          fi
+
+          CHANGED=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename' || true)
+          if [[ -z "$CHANGED" ]]; then
+            echo "docs-only=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Could not list PR files via API — defaulting to full pipeline."
+            exit 0
+          fi
+
+          echo "::group::Changed files in PR #$PR_NUMBER"
+          echo "$CHANGED"
+          echo "::endgroup::"
+
+          # A PR is docs-only when *every* changed file matches one of these patterns.
+          # Adding a new pattern? Remember: code that silently depends on markdown at runtime
+          # (e.g. loaded content) will be under-tested by a docs-only skip.
+          DOCS_ONLY=true
+          NON_DOC_FILE=""
+          while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+            case "$file" in
+              *.md|*.mdx) ;;
+              docs/*|*/docs/*) ;;
+              LICENSE|LICENSE.*|*/LICENSE|*/LICENSE.*) ;;
+              *) DOCS_ONLY=false; NON_DOC_FILE="$file"; break ;;
+            esac
+          done <<< "$CHANGED"
+
+          echo "docs-only=$DOCS_ONLY" >> "$GITHUB_OUTPUT"
+          if [[ "$DOCS_ONLY" == "true" ]]; then
+            echo "::notice::PR contains only docs/LICENSE changes — test/build/deploy will be skipped."
+          else
+            echo "Non-docs file detected: $NON_DOC_FILE — running full pipeline."
+          fi
+
       - name: 📊 Pipeline Summary
         shell: bash
         env:
@@ -770,7 +825,7 @@ jobs:
     permissions:
       contents: read
     needs: setup
-    if: needs.setup.outputs.enable-test == 'true'
+    if: needs.setup.outputs.enable-test == 'true' && needs.setup.outputs.docs-only != 'true'
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -817,6 +872,7 @@ jobs:
     if: |
       always() &&
       needs.setup.outputs.enable-build == 'true' &&
+      needs.setup.outputs.docs-only != 'true' &&
       (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
       (needs.test.result == 'success' || needs.test.result == 'skipped')
     steps:
@@ -900,6 +956,7 @@ jobs:
       always() &&
       needs.setup.outputs.enable-deploy == 'true' &&
       needs.setup.outputs.deploy-provider == 'vercel' &&
+      needs.setup.outputs.docs-only != 'true' &&
       (needs.build.result == 'success' || needs.build.result == 'skipped')
     strategy:
       fail-fast: false
@@ -979,6 +1036,7 @@ jobs:
       always() &&
       needs.setup.outputs.enable-deploy == 'true' &&
       needs.setup.outputs.deploy-provider == 'digitalocean' &&
+      needs.setup.outputs.docs-only != 'true' &&
       (needs.build.result == 'success' || needs.build.result == 'skipped')
     strategy:
       fail-fast: false
@@ -1017,6 +1075,7 @@ jobs:
       always() &&
       needs.setup.outputs.enable-deploy == 'true' &&
       needs.setup.outputs.deploy-provider == 'docker' &&
+      needs.setup.outputs.docs-only != 'true' &&
       (needs.build.result == 'success' || needs.build.result == 'skipped') &&
       (needs.release.result == 'success' || needs.release.result == 'skipped')
     strategy:

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -117,7 +117,7 @@ on:
         required: false
 
 # NOTE: Calling workflows must grant the permissions each job actually uses:
-#   setup:     contents: read
+#   setup:     contents: read, pull-requests: read (PR Files API for docs-only detection)
 #   security:  contents: read, pull-requests: write
 #   lint/test: contents: read
 #   build:     contents: read, id-token: write, attestations: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -483,13 +483,62 @@ Find the SHA-pinned `uses:` line, update both the SHA and the version comment. V
 
 ---
 
-## 14. Known Limitations
+## 14. Skipping CI Runs
+
+The pipeline has three ways to avoid burning CI minutes on work that doesn't need full validation.
+
+### Auto-skip on docs-only PRs (v2.6.10+)
+
+When a pull request's changed file list matches only these patterns, the pipeline automatically skips `test`, `build`, and all `deploy-*` jobs:
+
+- `**/*.md`, `**/*.mdx`
+- `docs/**`, `**/docs/**`
+- `**/LICENSE`, `**/LICENSE.*`
+
+`security` and `lint` still run — they're fast and can catch issues in markdown/config too. `release` and `sync-to-dev` still run on push events so docs commits land in changelogs as intended.
+
+The classification uses the GitHub PR Files API from the `setup` job, so it works without any extra git fetch. If the API lookup fails, the pipeline falls back to a full run (safe default). Detection only applies to `pull_request` events — `push` events (e.g. merges to `dev`/`main`) always run the full pipeline so deploys aren't silently skipped.
+
+### Native `[skip ci]` in commit messages
+
+GitHub natively skips **all workflow runs** for a push/PR when the head commit message contains any of these markers:
+
+- `[skip ci]`
+- `[ci skip]`
+- `[no ci]`
+- `[skip actions]`
+- `[actions skip]`
+
+Use this for commits that genuinely don't need any CI (e.g. `chore: fix typo in trailing comment`). **Caveat:** required status checks won't report, so PRs can't be merged without manually re-running CI first. Safer for push commits on feature branches than for PRs headed to merge.
+
+### Draft PRs
+
+By default, draft PRs still trigger the full pipeline — GitHub's default `pull_request` event includes drafts. Consumer caller workflows that want to skip CI on drafts can add:
+
+```yaml
+on:
+  pull_request:
+    branches: [main, dev]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  pipeline:
+    if: github.event.pull_request.draft == false
+    uses: navigaite/.github/.github/workflows/universal-pipeline.yaml@v2
+    ...
+```
+
+The `ready_for_review` trigger type is required — without it, un-drafting a PR doesn't fire a new workflow run, so the pipeline would never execute. This is a per-consumer opt-in; not all repos want draft skip.
+
+---
+
+## 15. Known Limitations
 
 - **Skipped deploy jobs show `${{ matrix.environment }}`** in the GitHub Actions sidebar. When a matrix job is skipped (e.g. `deploy-vercel` when provider is `none`), the matrix expression is never resolved so GitHub shows it raw. Cosmetic only — jobs are properly skipped and don't affect the pipeline result.
 
 ---
 
-## 15. Further Reading
+## 16. Further Reading
 
 - `docs/GETTING_STARTED.md` — 5-minute consumer quickstart.
 - `docs/CONFIGURATION.md` — full `pipeline.yaml` reference.


### PR DESCRIPTION
## Summary

Adds automatic pipeline-stage skipping for pull requests where *every* changed file is docs (`**/*.md`, `**/*.mdx`, `docs/**`, `**/docs/**`, `LICENSE`). Combines two wins from the CI cost-optimization audit:

- **A**: Documents GitHub's native `[skip ci]` / `[skip actions]` commit-message markers in `AGENTS.md`.
- **B**: New docs-only auto-skip in the shared pipeline — implemented here.
- Bonus: documents the opt-in **draft-PR skip** pattern for consumer caller workflows that want it.

## How it works

A new `Detect Docs-Only Changes` step in the `setup` job:

1. Fires only on `pull_request` events — push events (merges to `dev`/`main`) always run the full pipeline so deploys aren't silently bypassed.
2. Calls `gh api repos/<repo>/pulls/<n>/files` — no extra git fetch, no third-party action.
3. Outputs `docs-only=true` iff every changed file matches a docs pattern.
4. Falls back to `docs-only=false` (full pipeline) if the API lookup fails.

The following jobs gain `&& needs.setup.outputs.docs-only != 'true'` in their `if:`:

- `test`
- `build`
- `deploy-vercel`
- `deploy-digitalocean`
- `deploy-docker`

Still always run:
- `security`, `lint` — cheap, catch issues in docs too (trunk/actionlint etc.)
- `release`, `sync-to-dev` — only run on push events anyway; docs commits still need changelog entries.

`Check Gate` (both inside the reusable and in caller workflows) already treats `skipped` as passing, so docs-only PRs mark the required check green without side effects.

## Impact

On Edilio, a typical docs/README PR goes from ~6 min pipeline wall-clock (setup + security + lint + test + build) to ~1 min (setup + security + lint). The docs PR we just merged (#112) would have run Test 3:33 + Build 1:04 = ~4:40 of avoidable work.

Multiplies across every Node consumer. No effect on non-PR events.

## Safety

- Detection is PR-scoped; push events always run full pipeline.
- API failure → full pipeline (safe default).
- Pattern list is conservative (docs + LICENSE only). Config files like `.github/pipeline.yaml` or any `.yaml`/`.ts`/`.js`/`.json` change → full pipeline.
- `Check Gate` semantics unchanged: skipped jobs pass the gate, failures/cancellations fail it.
- Permission added to setup: `pull-requests: read` (required for the Files API lookup).

## Test plan

- [ ] `ci.yaml` still passes (actionlint + composite action validation)
- [ ] Smoke-test with a pure-docs PR against `dev` on a consumer repo — expect `test`/`build` to show as skipped, Check Gate green.
- [ ] Smoke-test with a mixed docs+code PR — expect full pipeline to run.
- [ ] Smoke-test a push to `dev` (non-PR) — expect full pipeline regardless of file list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)