### PR TITLE
docs: sync README, getting-started, configuration to v2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,28 @@ The Universal Pipeline is a **reusable GitHub Actions workflow** that auto-detec
 | | |
 |:--|:--|
 | **Stacks** | Node.js, Python, Flutter (auto-detected) |
-| **Deploy** | Vercel, DigitalOcean, Docker |
+| **Deploy** | Vercel, DigitalOcean, Docker (Coolify + Render as standalone composites) |
 | **Security** | TruffleHog, dependency review, Trivy, SLSA attestations |
 | **Releases** | release-please or semantic-release with conventional commits |
+| **Caching** | Dependency caches + automatic **Turborepo** remote cache (v2.6.9+) |
+| **Skip-on-docs** | PRs touching only `*.md` / `docs/**` skip test+build+deploy (v2.7.0+) |
+| **AI review** | Reusable Claude Code workflow for `@claude` PR reviews + fix commands |
 | **Maintenance** | Nightly security audits, cache cleanup, dependency checks |
+
+### What's new in v2.7.0 (2026-04-20)
+
+- **Docs-only PR skip** — test, build and deploy jobs are skipped automatically on pull requests that change only markdown / `docs/**` / `LICENSE*` files ([#116](https://github.com/navigaite/.github/pull/116)). See [AGENTS.md §14](./AGENTS.md).
+- **Turborepo cache across runs** (v2.6.9) — `run-tests` and `run-build` restore and save `node_modules/.cache/turbo` automatically ([#114](https://github.com/navigaite/.github/pull/114)).
+- **Leaner dependency install** (v2.6.8) — redundant global `pnpm` install dropped from setup ([#112](https://github.com/navigaite/.github/pull/112)).
+- **Claude Code reliability** (v2.6.2 – v2.6.7) — app-token minting for bot-triggered runs, Copilot review repost, queueing instead of cancellation.
 
 ---
 
 ## Quick Start
 
-**1. Add the workflow** to your repo at `.github/workflows/ci.yaml`:
+**1. Add the workflow** to your repo at `.github/workflows/ci.yaml`.
+
+The template is **org-ruleset compliant** — the workflow `name:` and the `Branch Guard` / `Check Gate` job names are required for the ruleset "Protected branches" to match status checks. Do not rename them.
 
 ```yaml
 name: Navigaite Pipeline
@@ -57,6 +69,7 @@ jobs:
     name: Branch Guard
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - run: echo "Single-branch repo — all PRs target main directly"
 
@@ -71,6 +84,7 @@ jobs:
     if: always()
     needs: [pipeline]
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Evaluate pipeline result
         shell: bash

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -200,6 +200,24 @@ Enable dependency and build output caching.
 - Caches pub for Flutter
 - Uses GitHub Actions cache
 
+#### Turborepo cache (automatic, v2.6.9+)
+
+If the repo is a Turborepo monorepo, `run-tests` and `run-build` automatically restore and save `node_modules/.cache/turbo` using the GitHub Actions cache. No configuration needed.
+
+- **Test cache key:** `turbo-tests-${OS}-${branch}-${sha}` (with cross-branch fallback)
+- **Build cache key:** `turbo-build-${OS}-${branch}-${sha}` (with cross-branch fallback)
+- **Path:** `node_modules/.cache/turbo`
+
+On a cache hit, Turbo skips tasks whose inputs haven't changed — typically turning lint/test/build into near-no-ops on unrelated package changes.
+
+#### Docs-only PR auto-skip (automatic, v2.7.0+)
+
+When a pull request changes only files matching `**/*.md`, `**/*.mdx`, `docs/**`, `**/docs/**`, or `**/LICENSE*`, the pipeline automatically skips `test`, `build`, and all `deploy-*` jobs. `security` and `lint` still run.
+
+- **Applies only to `pull_request` events** — push events (including merges to `main`/`dev`) always run the full pipeline so releases and deploys aren't silently skipped.
+- Detection uses the GitHub PR Files API; if the lookup fails the pipeline falls back to a full run.
+- No configuration needed — opt-out by manually re-running workflow dispatch.
+
 ---
 
 ### `security` (optional)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -15,24 +15,64 @@ This guide will walk you through setting up the Universal CI/CD Pipeline v2 for 
 
 ### Step 1: Create Workflow File (1 min)
 
-Create `.github/workflows/ci.yaml` in your project:
+Create `.github/workflows/ci.yaml` in your project. The template below is **org-ruleset compliant** — it wires the mandatory `Branch Guard` and `Check Gate` status checks the org ruleset "Protected branches" requires.
+
+> **Do not rename the workflow or jobs.** The `name: Navigaite Pipeline` header and the bare job names `Branch Guard` / `Check Gate` are required for the org ruleset to match. See [AGENTS.md §8](../AGENTS.md) for the full naming convention.
 
 ```yaml
-name: CI/CD Pipeline
+name: Navigaite Pipeline
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
-    branches: [main, dev]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+  deployments: write
+  packages: write
+  id-token: write
+  attestations: write
+  security-events: write
 
 jobs:
+  branch-guard:
+    name: Branch Guard
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - run: echo "Single-branch repo — all PRs target main directly"
+
   pipeline:
     uses: navigaite/.github/.github/workflows/universal-pipeline.yaml@v2
     with:
       config-file: .github/pipeline.yaml
     secrets: inherit
+
+  check-gate:
+    name: Check Gate
+    if: always()
+    needs: [pipeline]
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Evaluate pipeline result
+        shell: bash
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          set -euo pipefail
+          FAILURES=$(echo "$RESULTS" | jq -r 'map(select(. == "failure" or . == "cancelled")) | length')
+          if [[ "$FAILURES" -gt 0 ]]; then
+            echo "::error::Pipeline failed — ${FAILURES} job(s) failed or were cancelled"
+            exit 1
+          fi
 ```
+
+> Using the `dev` + `main` profile (large repos)? The Branch Guard job must instead enforce that feature PRs target `dev` and only promotion/release-please/hotfix branches target `main`. See [AGENTS.md §4](../AGENTS.md) for the Profile B caller.
 
 ### Step 2: Create Configuration File (2 min)
 
@@ -330,6 +370,16 @@ runtime:
 2. Look for the red X to see which step failed
 3. Click on the failed step to see error messages
 
+## 🏃 Skipping CI When It Doesn't Matter
+
+The pipeline has three ways to avoid burning CI minutes on work that doesn't need full validation:
+
+**1. Auto-skip for docs-only PRs (v2.7.0+)** — pull requests that only touch `*.md`, `*.mdx`, `docs/**`, or `LICENSE*` files automatically skip `test`, `build`, and all `deploy-*` jobs. `security` and `lint` still run. Push events (merges to `main`/`dev`) always run the full pipeline so deploys are never silently skipped. Nothing to configure — it's on by default.
+
+**2. Native `[skip ci]` in commit messages** — include `[skip ci]`, `[ci skip]`, `[no ci]`, `[skip actions]`, or `[actions skip]` in the head commit message to skip all workflow runs entirely. Caveat: required status checks won't report, so PRs can't be merged without manually re-running CI.
+
+**3. Draft PR skip (opt-in)** — add `if: github.event.pull_request.draft == false` to your pipeline job and include `ready_for_review` in your PR `types:` to skip CI on drafts until marked ready. Example in [AGENTS.md §14](../AGENTS.md).
+
 ## 💡 Pro Tips
 
 1. **Start minimal**: Begin with just CI (no deployment), then add deployment later
@@ -337,6 +387,7 @@ runtime:
 3. **Test locally first**: Run `npm test`, `npm run build` locally before pushing
 4. **Check Actions tab**: Monitor your pipeline runs
 5. **Read the logs**: Error messages are usually very helpful
+6. **Leverage turbo caching**: If you use [Turborepo](https://turbo.build/), the pipeline automatically restores and saves `node_modules/.cache/turbo` across runs (v2.6.9+) — lint/test/build become near-instant on unchanged packages
 
 ## 🎓 Common Workflows
 


### PR DESCRIPTION
## Summary
- Adds "What's new in v2.7.0" to README — surfaces the docs-only PR skip (#116), turbo cache (#114) and pnpm install de-dup (#112) that landed without user-facing docs.
- Replaces the stale Getting Started caller template — it used \`name: CI/CD Pipeline\` and was missing \`Branch Guard\` / \`Check Gate\` jobs, which means any repo that copied it would fail the org ruleset "Protected branches" status-check match.
- Adds **Turborepo cache** and **Docs-only auto-skip** subsections to \`docs/CONFIGURATION.md\` under \`pipeline\`.
- Adds a "Skipping CI" section to Getting Started covering docs-only / \`[skip ci]\` / draft-PR patterns.

## Test plan
- [ ] Markdown renders correctly on GitHub
- [ ] Links from README / GETTING_STARTED resolve
- [ ] Caller template in Getting Started matches AGENTS.md §4 verbatim (required for org ruleset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)