### PR TITLE
perf(claude-code): cancel in-flight runs on the same PR

### DIFF
--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -103,6 +103,24 @@ on:
 
 permissions: {}
 
+# Collapse rapid-fire @claude invocations on the same PR into the latest
+# request. Without this, every comment spawns a fresh run that can burn
+# up to `timeout_minutes` of Claude API tokens in parallel — a noisy PR
+# thread can rack up $10-50/month of wasted spend plus Actions minutes.
+#
+# `cancel-in-progress: true` — "replace with latest" semantics. If a user
+# sends a follow-up `@claude` before the previous run finishes, cancel
+# the older run and work on the new request. For queue-instead-of-replace
+# semantics, flip this to `false`.
+#
+# Group key falls back from pull_request.number (review / review_comment
+# events) to issue.number (issue_comment events) to github.ref (manual
+# dispatch, workflow_call without a PR context) so every event shape
+# resolves to a stable group.
+concurrency:
+  group: claude-code-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Copilot PR reviews cannot run claude-code-action directly: its
   # `checkHumanActor` step calls `octokit.users.getByUsername('Copilot')`

--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -113,12 +113,14 @@ permissions: {}
 # the older run and work on the new request. For queue-instead-of-replace
 # semantics, flip this to `false`.
 #
-# Group key falls back from pull_request.number (review / review_comment
-# events) to issue.number (issue_comment events) to github.ref (manual
-# dispatch, workflow_call without a PR context) so every event shape
-# resolves to a stable group.
+# Group key is namespaced with caller repo + caller workflow name to
+# avoid collisions across workflows or consumer repos that happen to use
+# the same base key. Falls back from pull_request.number (review /
+# review_comment events) to issue.number (issue_comment events) to
+# github.ref (manual dispatch, workflow_call without a PR context) so
+# every event shape resolves to a stable group.
 concurrency:
-  group: claude-code-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  group: claude-code-${{ github.repository }}-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- Adds workflow-level `concurrency` to `claude-code.yaml` so rapid-fire `@claude` invocations on the same PR collapse into the latest request instead of spawning parallel Claude runs.
- Group key: `claude-code-<pr-number | issue-number | ref>` — covers every event shape (`pull_request_review`, `pull_request_review_comment`, `issue_comment`, and `workflow_call` without a PR context).
- `cancel-in-progress: true` → "replace with latest" semantics. Flip to `false` if queue-in-order is ever preferred.

## Why
Without this, a noisy PR thread can burn up to `timeout_minutes` (default 30) of Claude API tokens + Actions minutes per overlapping comment — potentially \$10-50/month of wasted spend on a single chatty PR.

## Test plan
- [ ] Trigger two rapid \`@claude\` comments on a test PR; verify the older run is cancelled, not queued
- [ ] Trigger \`@claude\` on two **different** PRs simultaneously; verify both proceed in parallel (different group keys)
- [ ] Verify Copilot-review repost path still works — the reposted `@claude` comment fires a second workflow run with the same PR number and correctly replaces any prior in-flight run

🤖 Generated with [Claude Code](https://claude.com/claude-code)