### PR TITLE
perf(ci): merge pipeline-summary + inner check-gate into one job

### DIFF
--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -1299,7 +1299,13 @@ jobs:
           create-pr: false
           auto-merge-pr: true
 
-  # ─── Pipeline Summary ───────────────────────────────────────────
+  # =============================================================================
+  # PIPELINE SUMMARY — aggregates results into a markdown table AND fails the
+  # reusable workflow if any required job failed or was cancelled. This job
+  # is the inner gate that surfaces failures to the caller's `pipeline` job
+  # result — the caller's own top-level `Check Gate` then maps that result
+  # into the org-ruleset-matched status check.
+  # =============================================================================
   pipeline-summary:
     name: 📊 Pipeline Summary
     runs-on: ubuntu-latest
@@ -1319,9 +1325,10 @@ jobs:
       - sync-to-dev
     if: always()
     steps:
-      - name: Generate Pipeline Summary
+      - name: Generate summary and evaluate pipeline result
         shell: bash
         env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
           SETUP: ${{ needs.setup.result }}
           SECURITY: ${{ needs.security.result }}
           LINT: ${{ needs.lint.result }}
@@ -1334,6 +1341,8 @@ jobs:
           SYNC: ${{ needs.sync-to-dev.result }}
         run: |
           set -euo pipefail
+          command -v jq >/dev/null || { echo "::error::jq not available"; exit 1; }
+
           status_icon() {
             case "$1" in
               success) echo "✅" ;;
@@ -1361,34 +1370,6 @@ jobs:
             echo "| Sync to Dev | $(status_icon "$SYNC") $SYNC |"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # =============================================================================
-  # CHECK GATE — single aggregator for org ruleset required status checks
-  # =============================================================================
-  check-gate:
-    name: Check Gate
-    if: always()
-    needs:
-      - setup
-      - security
-      - lint
-      - test
-      - build
-      - deploy-vercel
-      - deploy-digitalocean
-      - deploy-docker
-      - release
-      - sync-to-dev
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      - name: Evaluate pipeline result
-        shell: bash
-        env:
-          RESULTS: ${{ toJSON(needs.*.result) }}
-        run: |
-          set -euo pipefail
-          command -v jq >/dev/null || { echo "::error::jq not available"; exit 1; }
-          echo "Job results: $RESULTS"
           # Fail if any required job failed or was cancelled (skipped is OK)
           FAILURES=$(echo "$RESULTS" | jq -r 'map(select(. == "failure" or . == "cancelled")) | length')
           if [[ "$FAILURES" -gt 0 ]]; then


### PR DESCRIPTION
## Summary
The reusable workflow had **two** terminal jobs — \`pipeline-summary\` (writes markdown table) and \`check-gate\` (evaluates results and fails) — that both waited on the same 10-job \`needs:\` graph and ran trivial shell. Two runner boots per run (~10-15s each billable) for ~30s of actual work.

Collapsed into a single \`pipeline-summary\` job that writes the summary **and** evaluates results, preserving fail-fast behavior.

## Why this is safe
- The org ruleset \"Protected branches\" matches the **caller's** top-level \`Check Gate\` job (in the consumer's \`ci.yaml\`), **not** the inner one inside the reusable workflow. See AGENTS.md §8.
- The caller's Check Gate already aggregates the reusable pipeline's result via \`needs: [pipeline]\`, and that \`pipeline\` job's success/failure is determined by the reusable workflow's final failing job — which is now the merged \`pipeline-summary\`. Same observable semantics.
- Nothing in this repo or in consumer workflows references the inner \`check-gate\` by name. Verified via \`grep\`.

## Impact
Saves one runner boot per pipeline run: **~400 runner-min/mo ≈ \$3/mo** across the org. Wall-clock shaved by ~15s per run.

## Test plan
- [ ] Merge and observe a successful pipeline run — single \"📊 Pipeline Summary\" job appears instead of both \"📊 Pipeline Summary\" + \"Check Gate\"
- [ ] Open a PR that intentionally fails a stage (e.g. bad lint) — verify \`pipeline-summary\` job fails and the caller's top-level \`Check Gate\` also fails (because \`needs.pipeline.result == 'failure'\`)
- [ ] Verify the step summary markdown table renders as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)