### PR TITLE
feat(release): open release-please PRs in draft by default

### DIFF
--- a/.github/actions/release-management/action.yaml
+++ b/.github/actions/release-management/action.yaml
@@ -72,6 +72,18 @@ inputs:
     required: false
     default: ''
 
+  draft-pull-request:
+    description: >-
+      Open release-please PRs in draft mode. Defaults to 'true' so the
+      caller's full pipeline (test/build/deploy) does not run on every
+      merge to the release branch — the release PR only triggers the
+      full pipeline when a human marks it "ready for review", at which
+      point release-please has already aggregated all changes since the
+      last release. Set to 'false' for legacy behavior. Only applies to
+      the release-please strategy.
+    required: false
+    default: 'true'
+
 outputs:
   release-created:
     description: Whether a release was created
@@ -145,6 +157,7 @@ runs:
         config-file: ${{ inputs.config-file }}
         manifest-file: ${{ inputs.manifest-file || '.release-please-manifest.json' }}
         target-branch: ${{ inputs.target-branch || github.ref_name }}
+        draft-pull-request: ${{ inputs.draft-pull-request }}
 
     - name: Run Release Please (legacy mode)
       id: release-please
@@ -154,6 +167,7 @@ runs:
         token: ${{ inputs.github-token }}
         release-type: ${{ inputs.release-type }}
         target-branch: ${{ inputs.target-branch || github.ref_name }}
+        draft-pull-request: ${{ inputs.draft-pull-request }}
 
     - name: Run Semantic Release
       id: semantic-release

--- a/.github/config/schemas/pipeline-config.schema.json
+++ b/.github/config/schemas/pipeline-config.schema.json
@@ -367,6 +367,11 @@
           "type": "string",
           "description": "Target branch for back-merge after release",
           "default": "dev"
+        },
+        "draft_pull_request": {
+          "type": "boolean",
+          "description": "Open release-please PRs in draft mode so the caller's full pipeline does not run on every merge to the release branch. Marking the PR ready-for-review re-triggers CI. Only applies to the release-please strategy.",
+          "default": true
         }
       }
     }

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -264,6 +264,7 @@ jobs:
             RP_CONFIG_FILE=""
             RP_CONFIG_FILE_STABLE=""
             RP_MANIFEST_FILE=""
+            RP_DRAFT_PR="true"
           else
             echo "✓ Found configuration file: $CONFIG_FILE"
 

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -195,6 +195,7 @@ jobs:
       release-config-file: ${{ steps.parse-config.outputs.release-config-file }}
       release-config-file-stable: ${{ steps.parse-config.outputs.release-config-file-stable }}
       release-manifest-file: ${{ steps.parse-config.outputs.release-manifest-file }}
+      release-draft-pull-request: ${{ steps.parse-config.outputs.release-draft-pull-request }}
 
     steps:
       - name: 📥 Checkout code
@@ -334,6 +335,11 @@ jobs:
             RP_CONFIG_FILE_STABLE=$(yq -r '.release.config_file_stable // ""' "$CONFIG_FILE")
             RP_MANIFEST_FILE=$(yq -r '.release.manifest_file // ""' "$CONFIG_FILE")
 
+            # Open release-please PRs in draft by default so the caller's
+            # full pipeline doesn't run on every merge to the release branch.
+            # Release PRs are human-gated: marking them ready re-triggers CI.
+            RP_DRAFT_PR=$(yq '.release.draft_pull_request // true' "$CONFIG_FILE")
+
             # Validate release strategy
             if [[ "$RELEASE_STRATEGY" != "release-please" && "$RELEASE_STRATEGY" != "semantic-release" ]]; then
               echo "::warning::Invalid release.strategy '$RELEASE_STRATEGY'. Falling back to 'release-please'"
@@ -435,6 +441,7 @@ jobs:
           echo "release-config-file=$RP_CONFIG_FILE" >> $GITHUB_OUTPUT
           echo "release-config-file-stable=$RP_CONFIG_FILE_STABLE" >> $GITHUB_OUTPUT
           echo "release-manifest-file=$RP_MANIFEST_FILE" >> $GITHUB_OUTPUT
+          echo "release-draft-pull-request=$RP_DRAFT_PR" >> $GITHUB_OUTPUT
 
           echo ""
           echo "📦 Configuration Summary:"
@@ -1242,6 +1249,7 @@ jobs:
           prerelease: ${{ steps.prerelease.outputs.is-prerelease }}
           prerelease-type: ${{ steps.prerelease.outputs.prerelease-type }}
           release-type: ${{ needs.setup.outputs.release-type != '' && needs.setup.outputs.release-type || (needs.setup.outputs.stack == 'nodejs' && 'node' || needs.setup.outputs.stack == 'python' && 'python' || 'simple') }}
+          draft-pull-request: ${{ needs.setup.outputs.release-draft-pull-request }}
   # =============================================================================
   # SYNC MAIN TO DEV (After Release)
   # =============================================================================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # ready_for_review required — without it, un-drafting a PR doesn't
+    # fire a new run, so draft release-please PRs would never execute CI.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: write          # releases, tag updates
@@ -167,6 +170,11 @@ jobs:
       - run: echo "Single-branch repo — all PRs target main directly"
 
   pipeline:
+    # Skip draft PRs. release-please opens its release PRs as drafts by
+    # default (v2.8.0+) so the full pipeline doesn't run on every merge
+    # that updates the release PR's changelog — it only fires when a
+    # human marks the release PR ready to publish.
+    if: github.event.pull_request.draft != true
     uses: navigaite/.github/.github/workflows/universal-pipeline.yaml@v2
     with:
       config-file: .github/pipeline.yaml

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -210,6 +210,28 @@ If the repo is a Turborepo monorepo, `run-tests` and `run-build` automatically r
 
 On a cache hit, Turbo skips tasks whose inputs haven't changed — typically turning lint/test/build into near-no-ops on unrelated package changes.
 
+#### Draft release-please PRs (automatic, v2.8.0+)
+
+By default, release-please PRs are opened in **draft** mode. This prevents the full pipeline (test, build, deploy) from running every time a feature PR merges to the release branch and triggers a release-please re-run (which updates the existing release PR's changelog).
+
+- When the release is ready to publish, a human marks the release PR ready-for-review, which re-triggers the full pipeline.
+- If CI passes, the release PR can be merged, publishing the release.
+- Opt out per-repo via `release.draft_pull_request: false`.
+
+Your caller workflow **must** include `ready_for_review` in the PR `types:` and skip draft PRs — see [AGENTS.md §4](../AGENTS.md) for the updated template:
+
+```yaml
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  pipeline:
+    if: github.event.pull_request.draft != true
+    # ...
+```
+
 #### Docs-only PR auto-skip (automatic, v2.7.0+)
 
 When a pull request changes only files matching `**/*.md`, `**/*.mdx`, `docs/**`, `**/docs/**`, or `**/LICENSE*`, the pipeline automatically skips `test`, `build`, and all `deploy-*` jobs. `security` and `lint` still run.


### PR DESCRIPTION
## Summary
Every merge to the release branch (\`main\` in Profile A, \`dev\` in Profile B) triggers release-please to update the existing release PR's changelog. Each update fires the full pipeline — test, build, deploy — on work that isn't actually ready to release. Per the motivating case: [navigaite/edilio#114](https://github.com/navigaite/edilio/pull/114) has been re-running CI on every dev merge.

Now release-please PRs open (and stay) as **drafts**. The full pipeline only runs when a human marks the release PR ready-for-review — the natural signal that the release is ready to publish.

## Changes
- **\`release-management\` action** — new input \`draft-pull-request\` (default \`'true'\`), passed to both release-please-action invocations (manifest + legacy modes). Not used by semantic-release.
- **\`universal-pipeline.yaml\`** — parses \`release.draft_pull_request\` from pipeline.yaml (default \`true\`), pipes through setup job outputs into the release job.
- **\`pipeline-config.schema.json\`** — documents \`release.draft_pull_request\` (default \`true\`).
- **\`AGENTS.md\` §4** — updated caller template:
  - Adds \`types: [opened, synchronize, reopened, ready_for_review]\` — required for un-drafting to fire a new workflow run.
  - Adds \`if: github.event.pull_request.draft != true\` on the \`pipeline\` job.
  - Inline comments explaining why.
- **\`docs/CONFIGURATION.md\`** — new subsection under the pipeline section.

## Opt-out
Per-repo: add \`release.draft_pull_request: false\` to \`.github/pipeline.yaml\`.

## Migration for existing consumers
When pinned to \`@v2\`:
- Repos get the new default on next dispatch. Existing non-draft release PRs are re-drafted on the next release-please run.
- Caller workflows missing \`ready_for_review\` trigger type will need the one-line addition, otherwise un-drafting the release PR won't fire CI and the PR will never show required checks — blocking merge. AGENTS.md §4 documents the updated template.

## Test plan
- [ ] Merge and push a feature commit to \`main\` here → verify the release-please PR opens as draft
- [ ] Verify merging the (draft) release PR is blocked in the UI until marked ready
- [ ] Mark the release PR ready-for-review → verify full pipeline fires and Check Gate passes
- [ ] Set \`release.draft_pull_request: false\` in a consumer and verify PRs open non-draft
- [ ] Sanity: the release job itself is triggered by \`push\`, not \`pull_request\`, so draft-gating the caller's \`pipeline\` job does not block release publishing on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)