### PR TITLE
feat(docker): apply floating version tag to every image build

### DIFF
--- a/.github/actions/deploy-docker/action.yaml
+++ b/.github/actions/deploy-docker/action.yaml
@@ -22,6 +22,16 @@ inputs:
     required: false
     default: ${{ github.sha }}
 
+  version-tag:
+    description: >-
+      Optional floating version tag (e.g. `1.2.3` or `0.3.0-beta.26`) applied
+      in addition to the primary image-tag. Typically sourced from the
+      release-please manifest so every build within a release cycle is
+      tagged with the target version. The tag moves to the most recent
+      build; per-commit uniqueness is preserved by sha-based tags.
+    required: false
+    default: ''
+
   registry:
     description: Container registry (dockerhub, ghcr, gcr, ecr, custom)
     required: false
@@ -135,6 +145,7 @@ runs:
           type=semver,pattern={{major}}.{{minor}}
           type=sha,prefix={{branch}}-
           type=raw,value=${{ inputs.image-tag }}
+          type=raw,value=${{ inputs.version-tag }},enable=${{ inputs.version-tag != '' }}
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and Push Docker Image

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -1120,6 +1120,7 @@ jobs:
           IMAGE_NAME_OVERRIDE: ${{ matrix.image.image_name }}
           IMAGE_SUFFIX: ${{ matrix.image.name }}
           RELEASE_VERSION: ${{ needs.release.outputs.release-version }}
+          MANIFEST_FILE: ${{ needs.setup.outputs.release-manifest-file }}
           EXTRA_BUILD_ARGS: ${{ matrix.image.build_args }}
         run: |
           set -euo pipefail
@@ -1135,21 +1136,36 @@ jobs:
           fi
 
           # Determine image tag: release version > git sha
+          # (primary tag; uniquely identifies this specific build)
           if [[ -n "$RELEASE_VERSION" ]]; then
             IMAGE_TAG="$RELEASE_VERSION"
           else
             IMAGE_TAG="${GITHUB_SHA}"
           fi
 
-          # Build args: always inject APP_VERSION when release version is known
-          BUILD_ARGS="${EXTRA_BUILD_ARGS}"
+          # Determine floating version tag (applied in addition to image-tag
+          # on every build): release-please's release version on release
+          # commits, else the current version from the release-please
+          # manifest. The tag moves to the newest build within the same
+          # version cycle; per-build uniqueness is preserved by the
+          # dev-<sha> / full-sha tags.
+          VERSION_TAG=""
           if [[ -n "$RELEASE_VERSION" ]]; then
+            VERSION_TAG="$RELEASE_VERSION"
+          elif [[ -n "$MANIFEST_FILE" && -f "$MANIFEST_FILE" ]]; then
+            VERSION_TAG=$(jq -r '."." // empty' "$MANIFEST_FILE" 2>/dev/null || true)
+          fi
+
+          # Build args: inject APP_VERSION whenever a version is known
+          BUILD_ARGS="${EXTRA_BUILD_ARGS}"
+          if [[ -n "$VERSION_TAG" ]]; then
             BUILD_ARGS="${BUILD_ARGS:+${BUILD_ARGS}
-          }APP_VERSION=${RELEASE_VERSION}"
+          }APP_VERSION=${VERSION_TAG}"
           fi
 
           echo "image-name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
           echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "version-tag=$VERSION_TAG" >> "$GITHUB_OUTPUT"
           echo "build-args<<EOF" >> "$GITHUB_OUTPUT"
           echo "$BUILD_ARGS" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
@@ -1161,6 +1177,7 @@ jobs:
           context: ${{ matrix.image.context || '.' }}
           image-name: ${{ steps.resolve.outputs.image-name }}
           image-tag: ${{ steps.resolve.outputs.image-tag }}
+          version-tag: ${{ steps.resolve.outputs.version-tag }}
           registry: ${{ matrix.image.registry || 'ghcr' }}
           build-args: ${{ steps.resolve.outputs.build-args }}
           platforms: ${{ matrix.image.platforms || 'linux/amd64' }}

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -1156,11 +1156,13 @@ jobs:
             VERSION_TAG=$(jq -r '."." // empty' "$MANIFEST_FILE" 2>/dev/null || true)
           fi
 
-          # Build args: inject APP_VERSION whenever a version is known
+          # Build args: inject APP_VERSION whenever a version is known.
+          # Separator is an explicit $'\n' so YAML block indentation doesn't
+          # bleed into the value and break docker/build-push-action parsing.
           BUILD_ARGS="${EXTRA_BUILD_ARGS}"
           if [[ -n "$VERSION_TAG" ]]; then
-            BUILD_ARGS="${BUILD_ARGS:+${BUILD_ARGS}
-          }APP_VERSION=${VERSION_TAG}"
+            [[ -n "$BUILD_ARGS" ]] && BUILD_ARGS+=$'\n'
+            BUILD_ARGS+="APP_VERSION=${VERSION_TAG}"
           fi
 
           echo "image-name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Tag every ghcr image with a clean semver string sourced from release-please — release version on release commits, else the current version from `.release-please-manifest.json`.
- The version tag floats to the newest build within a cycle; per-build uniqueness is preserved by the existing `dev-<sha>` / full-sha tags.

## Why

Non-release commits on `dev`/`main` currently only carry `<sha>` variants, so the GHCR package listing is hard to read — you have to cross-reference commit hashes to know which beta cycle an image belongs to.

After this change, every image built during (e.g.) the `0.3.0-beta.26` cycle carries the `0.3.0-beta.26` tag, and the release commit itself keeps the tag frozen once no more work lands in that cycle.

## Changes

- `universal-pipeline.yaml` — resolve step reads the manifest version when no release was cut, outputs `version-tag`, threads it through to `deploy-docker`, and uses it for the `APP_VERSION` build arg.
- `deploy-docker/action.yaml` — new `version-tag` input that adds an extra `type=raw` tag to the metadata-action list when non-empty.

## Backward compatibility

Repos without release-please pass an empty `release-manifest-file` through `setup`, so `version-tag` stays empty and behavior is unchanged.

## Test plan

- [ ] Merge and let release-please cut a new v2.x.x.
- [ ] Watch the next edilio `dev` push — expect tags `dev`, `dev-<sha>`, `<full-sha>`, `0.3.0-beta.26` (or whatever is current), `latest`.
- [ ] Watch the next release-please merge — expect the same set, with the version tag matching the newly cut version.
- [ ] Confirm repos without release-please still tag as before.