### PR TITLE
fix(trunk-upgrade): sign bot commits via Contents API

### DIFF
--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -173,6 +173,11 @@ jobs:
             Auto-merges after `Check Gate` passes.
           delete-branch: true
           signoff: true
+          # Commit via the GitHub Contents API so the commit is signed with the
+          # GitHub App's verified key. Required by org rulesets that enforce
+          # `required_signatures` on protected branches (otherwise the PR is
+          # MERGE BLOCKED with reason "unsigned").
+          sign-commits: true
 
       - name: Enable auto-merge
         if: steps.cpr.outputs.pull-request-number != '' && steps.token.outputs.using == 'app'


### PR DESCRIPTION
## Summary

- Adds `sign-commits: true` to the `peter-evans/create-pull-request` step in the reusable trunk-upgrade workflow.
- The action now commits via the GitHub **Contents API**, which signs the commit with the GitHub App's verified key (`navigaite-workflow-app[bot]`), instead of pushing via raw `git`.

## Why

Org rulesets enforce `required_signatures` on protected branches. Every weekly trunk-upgrade PR has been landing as `mergeStateStatus: BLOCKED` with `verified: false, reason: "unsigned"` — so auto-merge silently never fires. Most recent example: navigaite/edilio#221 (commit `a90913a`, unsigned).

`signoff: true` (DCO trailer) does not satisfy `required_signatures` — it's a textual line, not a cryptographic signature.

After this change, future trunk-upgrade PRs will be `verified: true` and auto-merge as intended.

## Test plan

- [ ] Merge this PR.
- [ ] Re-dispatch `Trunk Upgrade` in `navigaite/edilio` (after closing #221 + deleting `chore/trunk-upgrade`).
- [ ] Confirm the new PR's commit shows ✅ Verified in GitHub UI and that auto-merge fires after `Check Gate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)