### PR TITLE
feat: extend docs-only detection to push events + tighten Claude Code Fix triggers

### DIFF
--- a/.github/config/templates/claude-code-fix.yaml
+++ b/.github/config/templates/claude-code-fix.yaml
@@ -4,8 +4,14 @@
 name: Claude Code Fix
 
 on:
-  pull_request_review_comment:
-    types: [created]
+  # Only listen to top-level PR comments. We deliberately drop
+  # `pull_request_review_comment` because a single Copilot/human review
+  # with N inline comments fires N events, each of which spawns a
+  # workflow-run shell (visible as "Action required" pile-up when the
+  # commenter is a bot, even though the job-level `if:` would skip).
+  # A reviewer who wants to invoke Claude can write `@claude …` in the
+  # review body itself or as a separate PR comment — both surface as
+  # `issue_comment` events.
   issue_comment:
     types: [created]
 
@@ -15,7 +21,7 @@ on:
 # auto-coalesces further events into the queued slot, so rapid-fire
 # reviews collapse to one pending run without stranded indicators.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 permissions: {}
@@ -27,18 +33,15 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write          # required for claude-code-action OIDC token
-    # Manual on-demand only: require `@claude` in the comment body and a
-    # trusted author_association. Automatic Copilot → Claude auto-fix
-    # was removed.
+    # Manual on-demand only: require `@claude` in the comment body, a
+    # trusted author_association, and a human (non-bot) commenter so a
+    # bot quoting `@claude` cannot trigger a privileged run. Automatic
+    # Copilot → Claude auto-fix was removed.
     if: >-
-      (github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-                 github.event.comment.author_association)) ||
-      (github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-                 github.event.comment.author_association))
+      github.event.issue.pull_request &&
+      github.event.comment.user.type != 'Bot' &&
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+               github.event.comment.author_association)
     uses: navigaite/.github/.github/workflows/claude-code.yaml@v2
     secrets: inherit

--- a/.github/workflows/claude-code-fix.yaml
+++ b/.github/workflows/claude-code-fix.yaml
@@ -4,8 +4,14 @@
 name: Claude Code Fix
 
 on:
-  pull_request_review_comment:
-    types: [created]
+  # Only listen to top-level PR comments. We deliberately drop
+  # `pull_request_review_comment` because a single Copilot/human review
+  # with N inline comments fires N events, each of which spawns a
+  # workflow-run shell (visible as "Action required" pile-up when the
+  # commenter is a bot, even though the job-level `if:` would skip).
+  # A reviewer who wants to invoke Claude can write `@claude …` in the
+  # review body itself or as a separate PR comment — both surface as
+  # `issue_comment` events.
   issue_comment:
     types: [created]
 
@@ -15,7 +21,7 @@ on:
 # auto-coalesces further events into the queued slot, so rapid-fire
 # reviews collapse to one pending run without stranded indicators.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 permissions: {}
@@ -27,18 +33,16 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write          # required for claude-code-action OIDC token
-    # Manual on-demand only: require `@claude` in the comment body and a
-    # trusted author_association. Automatic Copilot → Claude auto-fix
-    # was removed.
+    # Manual on-demand only: require `@claude` in the comment body, a
+    # trusted author_association, and a human (non-bot) commenter so a
+    # bot quoting `@claude` (e.g. Copilot's review body echoing prior
+    # discussion) cannot trigger a privileged run. Automatic
+    # Copilot → Claude auto-fix was removed.
     if: >-
-      (github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-                 github.event.comment.author_association)) ||
-      (github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-                 github.event.comment.author_association))
+      github.event.issue.pull_request &&
+      github.event.comment.user.type != 'Bot' &&
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+               github.event.comment.author_association)
     uses: navigaite/.github/.github/workflows/claude-code.yaml@v2
     secrets: inherit

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -204,6 +204,11 @@ jobs:
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # fetch-depth 2 lets the docs-only detector compare HEAD against
+          # its parent on push events. PR events use the Files API and
+          # don't need history.
+          fetch-depth: 2
 
       - name: 📋 Parse Configuration
         id: parse-config
@@ -483,30 +488,46 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
         run: |
           set -euo pipefail
-          # Only classify docs-only for pull_request events. push events (merge to main/dev)
-          # always run the full pipeline so deploy/release don't get silently skipped.
-          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+          # Resolve the list of changed files for both pull_request and push events.
+          # Skipping heavy jobs on docs-only changes saves Actions minutes; deploy
+          # remains independently gated by the caller's skip-deploy expression
+          # (typically only release-please commits), so a docs-only push to dev
+          # that *is* a release-please merge still deploys correctly.
+          CHANGED=""
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            CHANGED=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename' || true)
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            # First push to a new branch or force-push: github.event.before may be
+            # 0000…0000. Fall back to diffing against HEAD~1 (requires fetch-depth ≥ 2).
+            if [[ -z "$PUSH_BEFORE" || "$PUSH_BEFORE" == "0000000000000000000000000000000000000000" ]]; then
+              CHANGED=$(git diff --name-only "HEAD~1" "$PUSH_AFTER" 2>/dev/null || true)
+            else
+              CHANGED=$(git diff --name-only "$PUSH_BEFORE" "$PUSH_AFTER" 2>/dev/null || true)
+            fi
+          else
             echo "docs-only=false" >> "$GITHUB_OUTPUT"
-            echo "Event '$EVENT_NAME' — docs-only detection only applies to pull_request."
+            echo "Event '$EVENT_NAME' — docs-only detection not applicable."
             exit 0
           fi
 
-          CHANGED=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename' || true)
           if [[ -z "$CHANGED" ]]; then
             echo "docs-only=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Could not list PR files via API — defaulting to full pipeline."
+            echo "::notice::Could not list changed files — defaulting to full pipeline."
             exit 0
           fi
 
-          echo "::group::Changed files in PR #$PR_NUMBER"
+          echo "::group::Changed files ($EVENT_NAME)"
           echo "$CHANGED"
           echo "::endgroup::"
 
-          # A PR is docs-only when *every* changed file matches one of these patterns.
-          # Adding a new pattern? Remember: code that silently depends on markdown at runtime
-          # (e.g. loaded content) will be under-tested by a docs-only skip.
+          # A change-set is docs-only when *every* changed file matches one of these
+          # patterns. Adding a new pattern? Remember: code that silently depends on
+          # markdown at runtime (e.g. loaded content) will be under-tested by a
+          # docs-only skip.
           DOCS_ONLY=true
           NON_DOC_FILE=""
           while IFS= read -r file; do
@@ -521,7 +542,7 @@ jobs:
 
           echo "docs-only=$DOCS_ONLY" >> "$GITHUB_OUTPUT"
           if [[ "$DOCS_ONLY" == "true" ]]; then
-            echo "::notice::PR contains only docs/LICENSE changes — security, lint, test, build, and deploy will be skipped."
+            echo "::notice::Only docs/LICENSE changes detected — security, lint, test, build will be skipped."
           else
             echo "Non-docs file detected: $NON_DOC_FILE — running full pipeline."
           fi


### PR DESCRIPTION
## Summary
- **universal-pipeline**: `docs-only` skip now fires on `push` as well as `pull_request`. Pushes to dev/main containing only markdown (e.g. marketing-content squash merges) no longer trigger security/lint/test/build.
- **claude-code-fix template + caller**: drop `pull_request_review_comment` and add a non-bot sender guard. Stops the `Action required` pile-up from Copilot inline-review comments. Only top-level PR comments with `@claude` from a human member now trigger Claude.

## Why
Customer noticed Actions budgets burning fast. Two root causes:
1. Docs-only pushes (post-merge squash) ran the full pipeline because docs-only detection had been gated to PR events only.
2. Every Copilot review with N inline comments created N \`Action required\` workflow-run shells for Claude Code Fix.

## Test plan
- [ ] Push a markdown-only commit to dev in a consumer repo, confirm the pipeline summary shows security/lint/test/build skipped.
- [ ] Trigger a Copilot review on a PR in a consumer repo, confirm no Claude Code Fix runs appear.
- [ ] Member comments \`@claude help\` on a PR → Claude Code Fix run fires.
- [ ] Push a non-docs change to dev → full pipeline runs.

## Rollout
Consumer repos pick up the universal-pipeline change automatically via the \`@v2\` tag once a release ships. The Claude Code Fix template change reaches consumer repos the next time \`bootstrap-maintenance.sh\` runs.