### PR TITLE
chore(ci): bootstrap org maintenance automation

### DIFF
--- a/.github/workflows/claude-code-fix.yaml
+++ b/.github/workflows/claude-code-fix.yaml
@@ -35,8 +35,7 @@ jobs:
       id-token: write          # required for claude-code-action OIDC token
     # Manual on-demand only: require `@claude` in the comment body, a
     # trusted author_association, and a human (non-bot) commenter so a
-    # bot quoting `@claude` (e.g. Copilot's review body echoing prior
-    # discussion) cannot trigger a privileged run. Automatic
+    # bot quoting `@claude` cannot trigger a privileged run. Automatic
     # Copilot → Claude auto-fix was removed.
     if: >-
       github.event.issue.pull_request &&


### PR DESCRIPTION
Automated bootstrap from `navigaite/.github`. Installs:

- Weekly Dependabot updates (github-actions ecosystem).
- Staggered `Trunk Upgrade Scheduled` caller at `.github/workflows/trunk-upgrade-scheduled.yaml` that delegates to the reusable `trunk-upgrade` workflow in `navigaite/.github`. Auto-merges after CI.
- Thin `Claude Code Fix` caller at `.github/workflows/claude-code-fix.yaml` that delegates to the reusable `claude-code` workflow in `navigaite/.github`.

If this repo previously had caller-style `trunk-upgrade.yaml` or `claude-code.yaml` at those shared paths, they are removed here in favor of the new `-fix` / `-scheduled` naming. Reusable-workflow definitions (files with `on: workflow_call`) are preserved.

Managed by `scripts/bootstrap-maintenance.sh` — edits to these files will be overwritten on the next bootstrap run.

---

## Pipeline Compliance Audit

Not applicable — this is `navigaite/.github`, the meta repo that *provides* the universal pipeline. Consumer-side checks (caller `ci.yaml` shape, `pipeline.yaml`, etc.) don't apply.

See [AGENTS.md §10](https://github.com/navigaite/.github/blob/main/AGENTS.md) for conventions that govern this repo's own release/versioning workflow.
