### PR TITLE
feat: add OIDC support for Infisical secrets loading

### DIFF
--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -969,21 +969,42 @@ jobs:
         id: infisical-config
         shell: bash
         env:
+          INFISICAL_IDENTITY_ID: ${{ vars.INFISICAL_IDENTITY_ID || secrets.INFISICAL_IDENTITY_ID }}
           INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
           INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
           INFISICAL_PROJECT_SLUG: ${{ vars.INFISICAL_PROJECT_SLUG || secrets.INFISICAL_PROJECT_SLUG }}
           INFISICAL_ENV_SLUG: ${{ vars.INFISICAL_ENV_SLUG || secrets.INFISICAL_ENV_SLUG }}
         run: |
           set -euo pipefail
-          if [[ -n "$INFISICAL_CLIENT_ID" && -n "$INFISICAL_CLIENT_SECRET" && -n "$INFISICAL_PROJECT_SLUG" && -n "$INFISICAL_ENV_SLUG" ]]; then
+          if [[ -z "$INFISICAL_PROJECT_SLUG" || -z "$INFISICAL_ENV_SLUG" ]]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Infisical project/env slug missing, skipping secrets injection step"
+            exit 0
+          fi
+          if [[ -n "$INFISICAL_IDENTITY_ID" ]]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "method=oidc" >> "$GITHUB_OUTPUT"
+          elif [[ -n "$INFISICAL_CLIENT_ID" && -n "$INFISICAL_CLIENT_SECRET" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "method=universal" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Infisical configuration incomplete, skipping secrets injection step"
+            echo "::notice::Infisical auth incomplete (set vars.INFISICAL_IDENTITY_ID for OIDC, or secrets.INFISICAL_CLIENT_ID/SECRET for Universal Auth), skipping secrets injection step"
           fi
 
+      - name: 🔐 Load Infisical Secrets (OIDC)
+        if: steps.infisical-config.outputs.enabled == 'true' && steps.infisical-config.outputs.method == 'oidc'
+        uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
+        with:
+          method: oidc
+          identity-id: ${{ vars.INFISICAL_IDENTITY_ID || secrets.INFISICAL_IDENTITY_ID }}
+          project-slug: ${{ vars.INFISICAL_PROJECT_SLUG || secrets.INFISICAL_PROJECT_SLUG }}
+          env-slug: ${{ vars.INFISICAL_ENV_SLUG || secrets.INFISICAL_ENV_SLUG }}
+          domain: ${{ vars.INFISICAL_DOMAIN || secrets.INFISICAL_DOMAIN || 'https://app.infisical.com' }}
+          secret-path: ${{ vars.INFISICAL_SECRET_PATH || secrets.INFISICAL_SECRET_PATH || '/' }}
+
       - name: 🔐 Load Infisical Secrets (Universal Auth)
-        if: steps.infisical-config.outputs.enabled == 'true'
+        if: steps.infisical-config.outputs.enabled == 'true' && steps.infisical-config.outputs.method == 'universal'
         uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
         with:
           method: universal
@@ -1050,27 +1071,55 @@ jobs:
         shell: bash
         env:
           DEPLOY_ENVIRONMENT: ${{ matrix.environment }}
+          INFISICAL_IDENTITY_ID: ${{ vars.INFISICAL_IDENTITY_ID || secrets.INFISICAL_IDENTITY_ID }}
           INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
           INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
           INFISICAL_PROJECT_SLUG_RAW: ${{ vars.INFISICAL_PROJECT_SLUG || secrets.INFISICAL_PROJECT_SLUG }}
+          INFISICAL_PROD_ENV_SLUG: ${{ vars.INFISICAL_PROD_ENV_SLUG }}
+          INFISICAL_PREVIEW_ENV_SLUG: ${{ vars.INFISICAL_PREVIEW_ENV_SLUG }}
         run: |
           set -euo pipefail
+          # Map the GitHub deployment environment to an Infisical environment slug.
+          # Defaults match the most common Infisical project (production / preview),
+          # but can be overridden per repo by setting vars.INFISICAL_PROD_ENV_SLUG
+          # and vars.INFISICAL_PREVIEW_ENV_SLUG — for example, edilio uses
+          # `prod` and `staging`.
           case "${DEPLOY_ENVIRONMENT,,}" in
-          production) RESOLVED_ENV_SLUG="production" ;;
-          *) RESOLVED_ENV_SLUG="preview" ;;
+          production) RESOLVED_ENV_SLUG="${INFISICAL_PROD_ENV_SLUG:-production}" ;;
+          *) RESOLVED_ENV_SLUG="${INFISICAL_PREVIEW_ENV_SLUG:-preview}" ;;
           esac
 
-          if [[ -n "$INFISICAL_CLIENT_ID" && -n "$INFISICAL_CLIENT_SECRET" && -n "$INFISICAL_PROJECT_SLUG_RAW" ]]; then
+          if [[ -z "$INFISICAL_PROJECT_SLUG_RAW" ]]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "project-slug=$INFISICAL_PROJECT_SLUG_RAW" >> "$GITHUB_OUTPUT"
+          echo "env-slug=$RESOLVED_ENV_SLUG" >> "$GITHUB_OUTPUT"
+          if [[ -n "$INFISICAL_IDENTITY_ID" ]]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
-            echo "project-slug=$INFISICAL_PROJECT_SLUG_RAW" >> "$GITHUB_OUTPUT"
-            echo "env-slug=$RESOLVED_ENV_SLUG" >> "$GITHUB_OUTPUT"
-            echo "✅ Infisical deploy env slug: $RESOLVED_ENV_SLUG"
+            echo "method=oidc" >> "$GITHUB_OUTPUT"
+            echo "✅ Infisical deploy env slug: $RESOLVED_ENV_SLUG (OIDC)"
+          elif [[ -n "$INFISICAL_CLIENT_ID" && -n "$INFISICAL_CLIENT_SECRET" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "method=universal" >> "$GITHUB_OUTPUT"
+            echo "✅ Infisical deploy env slug: $RESOLVED_ENV_SLUG (Universal Auth)"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: 🔐 Load Infisical Secrets (OIDC)
+        if: steps.infisical-config.outputs.enabled == 'true' && steps.infisical-config.outputs.method == 'oidc'
+        uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
+        with:
+          method: oidc
+          identity-id: ${{ vars.INFISICAL_IDENTITY_ID || secrets.INFISICAL_IDENTITY_ID }}
+          project-slug: ${{ steps.infisical-config.outputs.project-slug }}
+          env-slug: ${{ steps.infisical-config.outputs.env-slug }}
+          domain: ${{ vars.INFISICAL_DOMAIN || secrets.INFISICAL_DOMAIN || 'https://app.infisical.com' }}
+          secret-path: ${{ vars.INFISICAL_SECRET_PATH || secrets.INFISICAL_SECRET_PATH || '/' }}
+
       - name: 🔐 Load Infisical Secrets (Universal Auth)
-        if: steps.infisical-config.outputs.enabled == 'true'
+        if: steps.infisical-config.outputs.enabled == 'true' && steps.infisical-config.outputs.method == 'universal'
         uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
         with:
           method: universal

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -107,6 +107,12 @@ on:
         required: false
       INFISICAL_CLIENT_SECRET:
         required: false
+      # Infisical Machine Identity ID for OIDC auth (preferred over Universal Auth).
+      # Typically set via `vars.INFISICAL_IDENTITY_ID` since the identity ID is
+      # not sensitive, but declared as a secret here so the `vars || secrets`
+      # fallback expression type-checks under actionlint.
+      INFISICAL_IDENTITY_ID:
+        required: false
       INFISICAL_PROJECT_SLUG:
         required: false
       INFISICAL_ENV_SLUG:

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -995,7 +995,7 @@ jobs:
             echo "method=universal" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Infisical auth incomplete (set vars.INFISICAL_IDENTITY_ID for OIDC, or secrets.INFISICAL_CLIENT_ID/SECRET for Universal Auth), skipping secrets injection step"
+            echo "::notice::Infisical auth incomplete (set vars.INFISICAL_IDENTITY_ID for OIDC, or secrets.INFISICAL_CLIENT_ID and secrets.INFISICAL_CLIENT_SECRET for Universal Auth), skipping secrets injection step"
           fi
 
       - name: 🔐 Load Infisical Secrets (OIDC)


### PR DESCRIPTION
## Summary

Adds OIDC as an alternative auth method for the Infisical `secrets-action` steps in both the build and deploy-vercel jobs. Backwards compatible — current Universal Auth callers keep working unchanged.

Detection logic per Infisical step:

1. If `vars.INFISICAL_IDENTITY_ID` (or `secrets.INFISICAL_IDENTITY_ID`) is set → **OIDC** (no long-lived creds).
2. Else if `secrets.INFISICAL_CLIENT_ID` + `INFISICAL_CLIENT_SECRET` are set → **Universal Auth** (status quo).
3. Else → step is skipped (status quo).

The build job already has `id-token: write`, and the deploy-vercel job inherits the same permission set, so no caller-side permission change is needed.

## Why

- Removes the strongest long-lived credential from repo-level GitHub Secrets.
- Aligns with Infisical's own [GitHub Actions docs](https://infisical.com/docs/integrations/cicd/githubactions) which recommend OIDC.
- Tracked as the future-state direction in `navigaite/edilio` ADR-0002.

## How a consumer repo opts in

1. Create a machine identity in Infisical, attach **OIDC auth**, trust `repo:<owner>/<repo>:*` (or tighter ref pattern).
2. Set GitHub repo variable `INFISICAL_IDENTITY_ID` to the identity UUID.
3. Remove the `INFISICAL_CLIENT_ID` / `INFISICAL_CLIENT_SECRET` repo secrets — no longer needed.

## Test plan

- [ ] Existing callers (universal-auth) — no behaviour change
- [ ] New caller with `INFISICAL_IDENTITY_ID` set — OIDC path activates, log message matches
- [ ] Caller with neither — step skipped gracefully (status quo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)