### PR TITLE
feat(workflows): add promote-to-main + hmac-cron-post reusables

### DIFF
--- a/.github/config/templates/claude-code-fix.yaml
+++ b/.github/config/templates/claude-code-fix.yaml
@@ -1,7 +1,7 @@
 # Managed by navigaite/.github bootstrap. Do not edit manually —
 # changes will be overwritten the next time bootstrap-maintenance.sh runs.
 ---
-name: Claude Code Fix
+name: 🤖 Claude Fix
 
 on:
   # Only listen to top-level PR comments. We deliberately drop

--- a/.github/config/templates/trunk-upgrade-scheduled.yaml
+++ b/.github/config/templates/trunk-upgrade-scheduled.yaml
@@ -4,7 +4,7 @@
 # The cron minute/hour is staggered per repo to avoid a PR storm across
 # all Navigaite repos. Bootstrap script substitutes __CRON__ at install time.
 ---
-name: Trunk Upgrade Scheduled
+name: 🧰 Trunk Upgrade
 
 on:
   schedule:

--- a/.github/workflows/claude-code-fix.yaml
+++ b/.github/workflows/claude-code-fix.yaml
@@ -1,7 +1,7 @@
 # Managed by navigaite/.github bootstrap. Do not edit manually —
 # changes will be overwritten the next time bootstrap-maintenance.sh runs.
 ---
-name: Claude Code Fix
+name: 🤖 Claude Fix
 
 on:
   # Only listen to top-level PR comments. We deliberately drop

--- a/.github/workflows/hmac-cron-post.yaml
+++ b/.github/workflows/hmac-cron-post.yaml
@@ -1,5 +1,5 @@
 ---
-name: HMAC Cron Post
+name: 🕒 HMAC Cron Post
 
 # Reusable workflow that POSTs an HMAC-signed empty request to a cron
 # endpoint on the deployed app. Callers supply only the endpoint path
@@ -17,6 +17,10 @@ on:
         description: Endpoint path (must start with `/`), e.g. `/api/cron/dunning`.
         required: true
         type: string
+    secrets:
+      CRON_HMAC_KEY:
+        description: HMAC key shared with the app server (matches runtime `verifyCronHmac`).
+        required: true
 
 permissions: {}
 

--- a/.github/workflows/hmac-cron-post.yaml
+++ b/.github/workflows/hmac-cron-post.yaml
@@ -1,0 +1,59 @@
+---
+name: HMAC Cron Post
+
+# Reusable workflow that POSTs an HMAC-signed empty request to a cron
+# endpoint on the deployed app. Callers supply only the endpoint path
+# (`/api/cron/dunning`, etc.) and a schedule. The signature scheme matches
+# the runtime `verifyCronHmac` helpers used across navigaite apps.
+#
+# Required secrets / vars on the caller repo:
+#   - `secrets.CRON_HMAC_KEY` — shared with the app server
+#   - `vars.CRON_BASE_URL` — public origin (no trailing slash), e.g. https://app.edilio.de
+
+on:
+  workflow_call:
+    inputs:
+      endpoint:
+        description: Endpoint path (must start with `/`), e.g. `/api/cron/dunning`.
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Build HMAC signature and POST
+        env:
+          CRON_BASE_URL: ${{ vars.CRON_BASE_URL }}
+          CRON_HMAC_KEY: ${{ secrets.CRON_HMAC_KEY }}
+          ENDPOINT: ${{ inputs.endpoint }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$CRON_HMAC_KEY" ]]; then
+            echo "::error::Secret CRON_HMAC_KEY is not configured on this repo."
+            exit 1
+          fi
+          if [[ -z "$CRON_BASE_URL" ]]; then
+            echo "::error::Repo variable CRON_BASE_URL is not configured."
+            exit 1
+          fi
+          if [[ "${ENDPOINT:0:1}" != "/" ]]; then
+            echo "::error::endpoint input must start with '/' (got '$ENDPOINT')."
+            exit 1
+          fi
+
+          TS=$(date +%s%3N)
+          NONCE=$(uuidgen)
+          PAYLOAD="${TS}.${NONCE}.${ENDPOINT}"
+          SIG=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$CRON_HMAC_KEY" -hex | awk '{print $2}')
+
+          echo "POSTing to ${CRON_BASE_URL}${ENDPOINT} at $TS"
+          curl --fail-with-body --silent --show-error -X POST \
+            "${CRON_BASE_URL}${ENDPOINT}" \
+            -H "X-Cron-Timestamp: $TS" \
+            -H "X-Cron-Nonce: $NONCE" \
+            -H "X-Cron-Signature: $SIG"

--- a/.github/workflows/hmac-cron-post.yaml
+++ b/.github/workflows/hmac-cron-post.yaml
@@ -41,6 +41,10 @@ jobs:
             echo "::error::Repo variable CRON_BASE_URL is not configured."
             exit 1
           fi
+          # Strip trailing slash to keep the concatenated URL canonical — a
+          # trailing slash would produce `//api/...` which breaks routing and
+          # HMAC verification (signed path would differ from request path).
+          CRON_BASE_URL="${CRON_BASE_URL%/}"
           if [[ "${ENDPOINT:0:1}" != "/" ]]; then
             echo "::error::endpoint input must start with '/' (got '$ENDPOINT')."
             exit 1

--- a/.github/workflows/promote-to-main.yaml
+++ b/.github/workflows/promote-to-main.yaml
@@ -87,10 +87,9 @@ jobs:
             exit 0
           fi
 
+          BODY=$(printf 'Automated promotion of %s commit(s) from `%s` to `%s`.\n\nMerge via the GitHub UI using **Merge commit** (not squash) to preserve conventional commit history and trigger downstream deploy/release workflows.\n' "$AHEAD" "$HEAD" "$BASE")
           URL=$(gh pr create --repo "$REPO" --base "$BASE" --head "$HEAD" \
             --title "chore: promote $HEAD → $BASE" \
-            --body "Automated promotion of $AHEAD commit(s) from \`$HEAD\` to \`$BASE\`.
-
-Merge via the GitHub UI using **Merge commit** (not squash) to preserve conventional commit history and trigger downstream deploy/release workflows.")
+            --body "$BODY")
           echo "Opened: $URL"
           echo "Opened promotion PR: [$URL]($URL)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-to-main.yaml
+++ b/.github/workflows/promote-to-main.yaml
@@ -1,5 +1,5 @@
 ---
-name: Promote dev → main
+name: 📤 Promote dev → main
 
 # Reusable workflow that opens a promotion PR from `dev` to `main` for
 # Profile B repos (large repos with dev + main + prereleases).

--- a/.github/workflows/promote-to-main.yaml
+++ b/.github/workflows/promote-to-main.yaml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.head }}
           fetch-depth: 0
@@ -72,8 +72,8 @@ jobs:
           fi
 
           # Precondition 2: source must have commits the target lacks.
-          BEHIND=$(git rev-list --count "origin/$BASE..origin/$HEAD")
-          if [[ "$BEHIND" -eq 0 ]]; then
+          AHEAD=$(git rev-list --count "origin/$BASE..origin/$HEAD")
+          if [[ "$AHEAD" -eq 0 ]]; then
             echo "::notice::$HEAD has no commits to promote to $BASE."
             exit 0
           fi
@@ -83,14 +83,14 @@ jobs:
             --state open --json url --jq '.[0].url // empty')
           if [[ -n "$EXISTING" ]]; then
             echo "::notice::Promotion PR already open: $EXISTING"
-            echo "summary=$EXISTING" >> "$GITHUB_STEP_SUMMARY"
+            echo "Promotion PR already open: [$EXISTING]($EXISTING)" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
           URL=$(gh pr create --repo "$REPO" --base "$BASE" --head "$HEAD" \
             --title "chore: promote $HEAD → $BASE" \
-            --body "Automated promotion of $BEHIND commit(s) from \`$HEAD\` to \`$BASE\`.
+            --body "Automated promotion of $AHEAD commit(s) from \`$HEAD\` to \`$BASE\`.
 
 Merge via the GitHub UI using **Merge commit** (not squash) to preserve conventional commit history and trigger downstream deploy/release workflows.")
           echo "Opened: $URL"
-          echo "Opened promotion PR: $URL" >> "$GITHUB_STEP_SUMMARY"
+          echo "Opened promotion PR: [$URL]($URL)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-to-main.yaml
+++ b/.github/workflows/promote-to-main.yaml
@@ -1,0 +1,96 @@
+---
+name: Promote dev → main
+
+# Reusable workflow that opens a promotion PR from `dev` to `main` for
+# Profile B repos (large repos with dev + main + prereleases).
+#
+# Why a workflow:
+#   - One-click promotion via Actions UI ("Run workflow" button) or via
+#     `gh workflow run promote.yml -R <owner>/<repo>` from external tools
+#     (AI-OS, automation).
+#   - Reusable so all Profile B repos share the same preconditions
+#     (no open release-please PR on dev, dev ahead of main, no duplicate
+#     promotion PR already open).
+#
+# The PR is intentionally NOT auto-merged: GitHub strips downstream
+# workflow triggers from GITHUB_TOKEN-initiated merges, and we want the
+# resulting push to main to fire the universal pipeline (deploy + Sentry
+# release). The operator merges the promotion PR via the GitHub UI.
+
+on:
+  workflow_call:
+    inputs:
+      head:
+        description: Source branch (default `dev`)
+        required: false
+        type: string
+        default: dev
+      base:
+        description: Target branch (default `main`)
+        required: false
+        type: string
+        default: main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Serialize concurrent triggers so the duplicate-PR precondition isn't racy
+# (two parallel `workflow_dispatch` runs could otherwise both pass the
+# existing-PR check before either `gh pr create` lands).
+concurrency:
+  group: promote-${{ github.repository }}-${{ inputs.head }}-${{ inputs.base }}
+  cancel-in-progress: false
+
+jobs:
+  open-promotion-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.head }}
+          fetch-depth: 0
+
+      - name: Open promotion PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD: ${{ inputs.head }}
+          BASE: ${{ inputs.base }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Precondition 1: no open release-please PR on the source branch
+          # (would race with the promotion and produce inconsistent changelogs).
+          OPEN_RP=$(gh pr list --repo "$REPO" --base "$HEAD" \
+            --json headRefName \
+            --jq '[.[] | select(.headRefName | startswith("release-please"))] | length')
+          if [[ "$OPEN_RP" -gt 0 ]]; then
+            echo "::error::Open release-please PR on $HEAD. Merge or close it before promoting."
+            exit 1
+          fi
+
+          # Precondition 2: source must have commits the target lacks.
+          BEHIND=$(git rev-list --count "origin/$BASE..origin/$HEAD")
+          if [[ "$BEHIND" -eq 0 ]]; then
+            echo "::notice::$HEAD has no commits to promote to $BASE."
+            exit 0
+          fi
+
+          # Precondition 3: skip if a promotion PR is already open.
+          EXISTING=$(gh pr list --repo "$REPO" --base "$BASE" --head "$HEAD" \
+            --state open --json url --jq '.[0].url // empty')
+          if [[ -n "$EXISTING" ]]; then
+            echo "::notice::Promotion PR already open: $EXISTING"
+            echo "summary=$EXISTING" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          URL=$(gh pr create --repo "$REPO" --base "$BASE" --head "$HEAD" \
+            --title "chore: promote $HEAD → $BASE" \
+            --body "Automated promotion of $BEHIND commit(s) from \`$HEAD\` to \`$BASE\`.
+
+Merge via the GitHub UI using **Merge commit** (not squash) to preserve conventional commit history and trigger downstream deploy/release workflows.")
+          echo "Opened: $URL"
+          echo "Opened promotion PR: $URL" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/trunk-upgrade-scheduled.yaml
+++ b/.github/workflows/trunk-upgrade-scheduled.yaml
@@ -4,7 +4,7 @@
 # The cron minute/hour is staggered per repo to avoid a PR storm across
 # all Navigaite repos. Bootstrap script substitutes 0 5 * * 2 at install time.
 ---
-name: Trunk Upgrade Scheduled
+name: 🧰 Trunk Upgrade
 
 on:
   schedule:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,17 +314,17 @@ jobs:
 
 ### [OPTIONAL] Workflow naming convention
 
-Use a single emoji prefix on each workflow `name:` field for visual scanning in the Actions tab. This is **purely cosmetic** and does **not** affect required check names (those come from job `name:` fields — see §8).
+Use a single emoji prefix on each workflow `name:` field for visual scanning in the Actions tab. This applies to **all workflow files** in this repo (reusables and callers) and to the **consumer / caller workflows** templated into downstream repos. It is **purely cosmetic** and does **not** affect required check names (those come from job `name:` fields — see §8).
 
-| Prefix | Usage |
-| --- | --- |
-| `🌙` | Nightly / scheduled maintenance |
-| `🌍` | Translation / localization |
-| `🕒` | Scheduled HMAC cron jobs |
-| `🏷️` | Label sync |
-| `🤖` | Claude / Copilot helpers |
-| `🧰` | Trunk upgrade and other tooling bumps |
-| `📤` | Promotion / release-orchestration triggers |
+| Prefix | Usage | Example |
+| --- | --- | --- |
+| `🌙` / `🗓️` | Nightly / weekly scheduled maintenance | `nightly-maintenance.yaml` |
+| `🌍` | Translation / localization | reserved |
+| `🕒` | Scheduled HMAC cron jobs (callers and the `hmac-cron-post` reusable) | `hmac-cron-post.yaml` |
+| `🏷️` | Label sync | reserved |
+| `🤖` | Claude / Copilot helpers | `claude-code.yaml`, `claude-code-fix.yaml` |
+| `🧰` / `🌲` | Trunk upgrade and other tooling bumps | `trunk-upgrade.yaml`, `trunk-upgrade-scheduled.yaml` |
+| `📤` | Promotion / release-orchestration triggers | `promote-to-main.yaml` |
 
 The main pipeline workflow keeps its bare `Navigaite Pipeline` name — that string is part of the required check naming contract.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ Consumer repos integrate by adding a thin caller workflow + a `.github/pipeline.
     create-release-pr.yaml     # Reusable: generate release PRs with changelog
     build-executables.yaml     # Reusable: PyInstaller cross-platform builds
     claude-code.yaml           # Reusable: Claude Code AI for PR reviews + @claude
+    hmac-cron-post.yaml        # Reusable: HMAC-signed POST to an app cron endpoint
+    promote-to-main.yaml       # Reusable: open dev → main promotion PR (Profile B)
     nightly-maintenance.yaml   # Scheduled: cache cleanup, security audits
     ci.yaml                    # CI: validates the composite actions and required check names
   actions/
@@ -262,6 +264,69 @@ Set `deployment.provider: none` and add your own job depending on `pipeline`:
     steps:
       - run: curl -sf "${{ secrets.RENDER_DEPLOY_HOOK }}"  # project-defined secret
 ```
+
+### [OPTIONAL] Promotion workflow (Profile B only)
+
+Adds a "Run workflow" button in the repo's Actions tab that opens a `dev → main` promotion PR. Useful for one-click promotion from the UI or `gh workflow run promote.yml -R <repo>` from automation.
+
+`.github/workflows/promote.yml`:
+
+```yaml
+name: 📤 Promote dev → main
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  promote:
+    uses: navigaite/.github/.github/workflows/promote-to-main.yaml@v2
+```
+
+The reusable validates preconditions (no open release-please PR on `dev`, `dev` ahead of `main`, no duplicate promotion PR) before opening. The PR is intentionally not auto-merged — GITHUB_TOKEN merges strip downstream workflow triggers, so the operator merges via the UI (Merge commit).
+
+### [OPTIONAL] HMAC-signed cron jobs
+
+For scheduled HMAC-signed POSTs to an app endpoint (e.g. nightly billing tasks), use the `hmac-cron-post.yaml` reusable instead of hand-rolling the openssl pipeline per cron.
+
+Requires `secrets.CRON_HMAC_KEY` (matches runtime) and `vars.CRON_BASE_URL` (public origin, no trailing slash) on the repo.
+
+`.github/workflows/cron-<name>.yml`:
+
+```yaml
+name: 🕒 <Display Name>
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch: {}
+concurrency:
+  group: cron-<name>
+  cancel-in-progress: false
+jobs:
+  run:
+    uses: navigaite/.github/.github/workflows/hmac-cron-post.yaml@v2
+    with:
+      endpoint: /api/cron/<name>
+    secrets: inherit
+```
+
+### [OPTIONAL] Workflow naming convention
+
+Use a single emoji prefix on each workflow `name:` field for visual scanning in the Actions tab. This is **purely cosmetic** and does **not** affect required check names (those come from job `name:` fields — see §8).
+
+| Prefix | Usage |
+| --- | --- |
+| `🌙` | Nightly / scheduled maintenance |
+| `🌍` | Translation / localization |
+| `🕒` | Scheduled HMAC cron jobs |
+| `🏷️` | Label sync |
+| `🤖` | Claude / Copilot helpers |
+| `🧰` | Trunk upgrade and other tooling bumps |
+| `📤` | Promotion / release-orchestration triggers |
+
+The main pipeline workflow keeps its bare `Navigaite Pipeline` name — that string is part of the required check naming contract.
 
 ---
 


### PR DESCRIPTION
## Summary
- **`promote-to-main.yaml`** — reusable `workflow_call` that opens a `dev → main` PR for Profile B repos. Validates preconditions (no open release-please PR on source, source ahead of target, no duplicate promotion PR) and serialises concurrent triggers via a `concurrency:` group so the duplicate-PR guard isn't racy. Intentionally does not auto-merge (`GITHUB_TOKEN`-initiated merges strip downstream triggers).
- **`hmac-cron-post.yaml`** — reusable that POSTs an HMAC-signed empty request to an app cron endpoint. Replaces ~30 lines of `openssl`/`curl` boilerplate that consumer repos (edilio currently runs 3 copies) duplicate per cron.
- **Bootstrap-managed template renames** — `claude-code-fix.yaml` → `🤖 Claude Fix`, `trunk-upgrade-scheduled.yaml` → `🧰 Trunk Upgrade`. Mirrored on this repo's own callers so they match.
- **AGENTS docs** — two new `[OPTIONAL]` sections (Promotion workflow, HMAC-signed cron jobs), workflow-name emoji convention table, repo-structure listing for the new reusables.

The job-level `name:` fields the org ruleset matches against (`Check Gate`, `Branch Guard`) are untouched — only top-level workflow `name:` fields gain emoji prefixes, which are cosmetic.

## Test plan
- [ ] CI green on this PR
- [ ] After merge + release: open follow-up PR in `navigaite/edilio` adding `promote.yml` caller + migrating the 3 cron files to `hmac-cron-post.yaml`
- [ ] Verify the bootstrap-script audit still passes against existing consumer repos (rename is in templates only — next bootstrap run re-syncs them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)