### PR TITLE
fix(docs): nudge v2 sha (codeload wedged on 33701f1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — Navigaite Universal CI/CD Pipeline
 
-> Organization-wide reusable GitHub Actions pipeline (`navigaite/.github`), currently at **v2**. For the exact released version see `CLAUDE.md` (updated automatically by release-please).
+> Organization-wide reusable GitHub Actions pipeline (`navigaite/.github`), currently at **v2** (rolling tag). For the exact released version see `CLAUDE.md` (updated automatically by release-please).
 
 This file is the single source of truth for AI coding agents (Claude, Copilot, Cursor, Codex, etc.) working in this repo **or** setting up this pipeline in a consumer repo. `CLAUDE.md` delegates here via `@AGENTS.md`.
 


### PR DESCRIPTION
## Summary
GitHub's codeload service has been returning 404 for `https://codeload.github.com/navigaite/.github/tar.gz/33701f158b25206d11798138ee54cd461b34c2cd` (the v2.12.0 tarball) since today's Actions outage. Confirmed across 5 consecutive workflow_dispatch runs on `navigaite/edilio` main — all fail at the Setup step with:

```
##[error]An action could not be found at the URI '…/33701f158b…'
##[error]Failed to download archive '…' after 1 attempts
```

Curling the same URL from outside Actions infrastructure returns 200, so this is GitHub-internal cache wedged on that specific sha.

This trivial doc tweak is a `fix:` so release-please cuts v2.12.1 (new sha). The rolling `v2` tag then advances, consumer callers pulling `@v2` get the new sha, and the codeload bug is bypassed.

## Test plan
- [ ] CI green
- [ ] After merge: release-please opens v2.12.1 PR, merge it
- [ ] Verify `@v2` moves to new sha
- [ ] Re-run `Navigaite Pipeline` on `navigaite/edilio` main — Setup step should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)