### PR TITLE
fix(ci): keep nightly green when Code Scanning is unavailable

### DIFF
--- a/.github/workflows/nightly-maintenance.yaml
+++ b/.github/workflows/nightly-maintenance.yaml
@@ -94,10 +94,11 @@ jobs:
 
       # Code Scanning requires GHAS on private repos. When unavailable,
       # upload-sarif fails with "Code scanning is not enabled for this
-      # repository". `continue-on-error: true` keeps the nightly green
-      # while still surfacing the failure as an annotation and in the
-      # summary table below — repos that later enable GHAS will start
-      # publishing SARIF automatically without any caller change.
+      # repository". `continue-on-error: true` keeps the scheduled
+      # maintenance run green while still surfacing the failure as an
+      # annotation and in the summary table below — repos that later
+      # enable GHAS will start publishing SARIF automatically without
+      # any caller change.
       - name: Upload Trivy results to GitHub Security
         id: sarif-upload
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3

--- a/.github/workflows/nightly-maintenance.yaml
+++ b/.github/workflows/nightly-maintenance.yaml
@@ -92,9 +92,17 @@ jobs:
             echo "::warning::Trivy did not produce trivy-results.sarif; skipping SARIF upload."
           fi
 
+      # Code Scanning requires GHAS on private repos. When unavailable,
+      # upload-sarif fails with "Code scanning is not enabled for this
+      # repository". `continue-on-error: true` keeps the nightly green
+      # while still surfacing the failure as an annotation and in the
+      # summary table below — repos that later enable GHAS will start
+      # publishing SARIF automatically without any caller change.
       - name: Upload Trivy results to GitHub Security
+        id: sarif-upload
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
-        if: always() && steps.trivy-output.outputs.exists == 'true'
+        if: steps.trivy-output.outputs.exists == 'true'
+        continue-on-error: true
         with:
           sarif_file: trivy-results.sarif
 
@@ -104,6 +112,7 @@ jobs:
         env:
           TRIVY_OUTCOME: ${{ steps.trivy-scan.outcome }}
           HAS_SARIF: ${{ steps.trivy-output.outputs.exists }}
+          SARIF_UPLOAD_OUTCOME: ${{ steps.sarif-upload.outcome }}
         run: |
           set -euo pipefail
           echo "### 🔒 Security Audit" >> $GITHUB_STEP_SUMMARY
@@ -112,6 +121,7 @@ jobs:
           echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
           echo "| Trivy Step | $TRIVY_OUTCOME |" >> $GITHUB_STEP_SUMMARY
           echo "| SARIF Produced | $HAS_SARIF |" >> $GITHUB_STEP_SUMMARY
+          echo "| SARIF Upload | ${SARIF_UPLOAD_OUTCOME:-skipped} |" >> $GITHUB_STEP_SUMMARY
 
   lint-workflows:
     name: 🔍 Lint Workflow Definitions


### PR DESCRIPTION
## Summary

- `github/codeql-action/upload-sarif` returns "Code scanning is not enabled for this repository" on private repos without GHAS — currently fails the entire `security-audit` job.
- Add `continue-on-error: true` + capture step outcome and surface it in the Security Audit step-summary table.
- Drop the redundant `always()` guard.

## Why

Every nightly maintenance run across consumers (platzl-finder, edilio, edilio-expense-nav, edilio-tfa) has been red for weeks because GHAS Code Scanning is not enabled. Trivy itself was running successfully — only the SARIF upload was failing. A red nightly trains us to ignore real alerts; this restores green for repos without GHAS while keeping uploads automatic once GHAS is enabled.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` parses clean
- [x] Codex review: no issues
- [ ] After merge → bump v2 major tag → re-run `gh workflow run nightly-maintenance.yaml` in `maxbec/platzl-finder` and confirm job is green
- [ ] Re-run in `navigaite/edilio` and confirm same

🤖 Generated with [Claude Code](https://claude.com/claude-code)