### PR TITLE
feat(release): add manifest_file_stable for per-stream manifests

### DIFF
--- a/.github/config/schemas/pipeline-config.schema.json
+++ b/.github/config/schemas/pipeline-config.schema.json
@@ -342,6 +342,10 @@
           "type": "string",
           "description": "release-please manifest file path"
         },
+        "manifest_file_stable": {
+          "type": "string",
+          "description": "Optional stable-branch release-please manifest file path"
+        },
         "prerelease_branches": {
           "type": "array",
           "description": "Branches that should publish prerelease versions",

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -205,6 +205,8 @@ jobs:
       release-config-file: ${{ steps.parse-config.outputs.release-config-file }}
       release-config-file-stable: ${{ steps.parse-config.outputs.release-config-file-stable }}
       release-manifest-file: ${{ steps.parse-config.outputs.release-manifest-file }}
+      release-manifest-file-stable: ${{ steps.parse-config.outputs.release-manifest-file-stable }}
+      release-manifest-file-resolved: ${{ steps.parse-config.outputs.release-manifest-file-resolved }}
       release-draft-pull-request: ${{ steps.parse-config.outputs.release-draft-pull-request }}
 
     steps:
@@ -279,6 +281,7 @@ jobs:
             RP_CONFIG_FILE=""
             RP_CONFIG_FILE_STABLE=""
             RP_MANIFEST_FILE=""
+            RP_MANIFEST_FILE_STABLE=""
             RP_DRAFT_PR="true"
           else
             echo "✓ Found configuration file: $CONFIG_FILE"
@@ -350,6 +353,7 @@ jobs:
             RP_CONFIG_FILE=$(yq -r '.release.config_file // ""' "$CONFIG_FILE")
             RP_CONFIG_FILE_STABLE=$(yq -r '.release.config_file_stable // ""' "$CONFIG_FILE")
             RP_MANIFEST_FILE=$(yq -r '.release.manifest_file // ""' "$CONFIG_FILE")
+            RP_MANIFEST_FILE_STABLE=$(yq -r '.release.manifest_file_stable // ""' "$CONFIG_FILE")
 
             # Open release-please PRs in draft by default so the caller's
             # full pipeline doesn't run on every merge to the release branch.
@@ -401,6 +405,24 @@ jobs:
           [[ "$SKIP_TEST" == "true" ]] && ENABLE_TEST="false"
           [[ "$SKIP_BUILD" == "true" ]] && ENABLE_BUILD="false"
           [[ "$SKIP_DEPLOY" == "true" ]] && ENABLE_DEPLOY="false"
+
+          # Resolve the branch-appropriate release-please manifest. On a
+          # non-prerelease branch (e.g. main) use the stable manifest when one
+          # is configured; otherwise the default manifest. Keeps the beta (dev)
+          # and stable (main) release streams in separate manifest files so
+          # dev<->main promotions never conflict on version state. Resolved
+          # once here so every consumer (release job + docker image tag) reads
+          # the same file.
+          RESOLVE_BRANCH="${GITHUB_REF#refs/heads/}"
+          RP_IS_PRERELEASE="false"
+          if [[ "$PRERELEASE_BRANCHES" != "[]" ]]; then
+            RP_LABEL=$(echo "$PRERELEASE_BRANCHES" | jq -r --arg b "$RESOLVE_BRANCH" '.[] | select(.branch == $b) | .label')
+            [[ -n "$RP_LABEL" ]] && RP_IS_PRERELEASE="true"
+          fi
+          RP_MANIFEST_RESOLVED="$RP_MANIFEST_FILE"
+          if [[ "$RP_IS_PRERELEASE" == "false" && -n "$RP_MANIFEST_FILE_STABLE" ]]; then
+            RP_MANIFEST_RESOLVED="$RP_MANIFEST_FILE_STABLE"
+          fi
 
           # Output configuration
           echo "configured-stack=$CONFIGURED_STACK" >> $GITHUB_OUTPUT
@@ -457,6 +479,8 @@ jobs:
           echo "release-config-file=$RP_CONFIG_FILE" >> $GITHUB_OUTPUT
           echo "release-config-file-stable=$RP_CONFIG_FILE_STABLE" >> $GITHUB_OUTPUT
           echo "release-manifest-file=$RP_MANIFEST_FILE" >> $GITHUB_OUTPUT
+          echo "release-manifest-file-stable=$RP_MANIFEST_FILE_STABLE" >> $GITHUB_OUTPUT
+          echo "release-manifest-file-resolved=$RP_MANIFEST_RESOLVED" >> $GITHUB_OUTPUT
           echo "release-draft-pull-request=$RP_DRAFT_PR" >> $GITHUB_OUTPUT
 
           echo ""
@@ -1226,7 +1250,7 @@ jobs:
           IMAGE_NAME_OVERRIDE: ${{ matrix.image.image_name }}
           IMAGE_SUFFIX: ${{ matrix.image.name }}
           RELEASE_VERSION: ${{ needs.release.outputs.release-version }}
-          MANIFEST_FILE: ${{ needs.setup.outputs.release-manifest-file }}
+          MANIFEST_FILE: ${{ needs.setup.outputs.release-manifest-file-resolved }}
           EXTRA_BUILD_ARGS: ${{ matrix.image.build_args }}
         run: |
           set -euo pipefail
@@ -1391,7 +1415,7 @@ jobs:
           force-patch-on-no-release: ${{ needs.setup.outputs.release-force-patch-on-no-release }}
           extra-plugins: ${{ needs.setup.outputs.release-extra-plugins }}
           config-file: ${{ steps.prerelease.outputs.config-file }}
-          manifest-file: ${{ needs.setup.outputs.release-manifest-file }}
+          manifest-file: ${{ needs.setup.outputs.release-manifest-file-resolved }}
           target-branch: ${{ github.ref_name }}
           prerelease: ${{ steps.prerelease.outputs.is-prerelease }}
           prerelease-type: ${{ steps.prerelease.outputs.prerelease-type }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,7 +361,8 @@ release:
   strategy: release-please
   config_file: release-please-config.json            # prerelease on dev
   config_file_stable: release-please-config.main.json # stable on main
-  manifest_file: .release-please-manifest.json
+  manifest_file: .release-please-manifest.dev.json    # beta stream (dev)
+  manifest_file_stable: .release-please-manifest.json # stable stream (main)
   sync_to_dev: true
   prerelease_branches:
     - branch: dev

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -680,7 +680,19 @@ Optional stable-branch `release-please` config file path for Profile B repos.
 
 **Type:** `string`
 
-Optional `release-please` manifest file path.
+Optional `release-please` manifest file path. Used as the **default** manifest
+on every branch unless `manifest_file_stable` is set and the branch is a
+non-prerelease (stable) branch.
+
+#### `release.manifest_file_stable`
+
+**Type:** `string`
+
+Optional stable-branch `release-please` manifest file path for Profile B repos
+(beta on `dev`, stable on `main`). When set, non-prerelease branches read/write
+this manifest while prerelease branches use `manifest_file`. Giving each release
+stream its own manifest file keeps `dev`<->`main` promotions from ever
+conflicting on version state. Pair it with `config_file_stable`.
 
 #### `release.prerelease_branches`
 


### PR DESCRIPTION
## Why

Profile B repos (beta on `dev`, stable on `main`) share ONE release-please manifest with the same package key, so the two streams write divergent versions into the same file and **every `dev`→`main` promotion conflicts on version state**. The action already supports `config_file` + `config_file_stable` (branch-selected) but only one `manifest_file`.

## What

- New `release.manifest_file_stable` config knob (mirrors `config_file_stable`).
- Resolved **once** in the `setup` job (`release-manifest-file-resolved`): non-prerelease branches use the stable manifest, prerelease branches keep `manifest_file`.
- Consumed by both the release job and the docker image-tag step so they never diverge.
- Docs: CONFIGURATION.md + AGENTS.md.

## Compatibility

Backward compatible: repos that only set `manifest_file` are unchanged (falls back to it on every branch).

## Follow-up

After merge, re-point the `v2` tag so consumers (edilio) pick this up. edilio's companion PR depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)