### PR TITLE
feat(release): auto-reconcile dev prerelease manifest after promotion to main (EDI-376)

### DIFF
--- a/.github/actions/sync-branches/action.yaml
+++ b/.github/actions/sync-branches/action.yaml
@@ -27,6 +27,33 @@ inputs:
     required: false
     default: 'true'
 
+  prerelease-manifest-file:
+    description: >-
+      Path to the dev/beta prerelease release-please manifest. When set
+      together with a different `stable-manifest-file`, the direct-push sync
+      reconciles each prerelease cursor in this file to the just-released
+      stable version (strips the `-beta.N` suffix) so the next dev release
+      computes a version above the released stable. Dual-track (Profile B)
+      repos only; leave empty to disable.
+    required: false
+    default: ''
+
+  stable-manifest-file:
+    description: >-
+      Path to the stable release-please manifest, used as the source of truth
+      for the reconciled base versions. Must differ from
+      `prerelease-manifest-file` for reconciliation to run.
+    required: false
+    default: ''
+
+  stable-version:
+    description: >-
+      Just-released stable version (e.g. release-please `release-version`).
+      Used as the fallback base for the root (".") manifest entry when the
+      stable manifest has no matching key.
+    required: false
+    default: ''
+
 runs:
   using: composite
   steps:
@@ -87,6 +114,9 @@ runs:
       env:
         SOURCE_BRANCH: ${{ inputs.source-branch }}
         TARGET_BRANCH: ${{ inputs.target-branch }}
+        PRERELEASE_MANIFEST_FILE: ${{ inputs.prerelease-manifest-file }}
+        STABLE_MANIFEST_FILE: ${{ inputs.stable-manifest-file }}
+        STABLE_VERSION: ${{ inputs.stable-version }}
       run: |
         set -euo pipefail
         echo "::group::🔄 Syncing $SOURCE_BRANCH → $TARGET_BRANCH"
@@ -103,6 +133,26 @@ runs:
           -m "chore: sync $SOURCE_BRANCH to $TARGET_BRANCH [skip ci]" \
           -m "Auto-sync from $SOURCE_BRANCH after release" \
           -m "This commit contains version updates and should not trigger a new release."
+
+        # Reconcile the dev (beta) prerelease manifest base to the just-released
+        # stable version so the next dev release computes a version ABOVE the
+        # released stable (dual-track / Profile B repos only). Folded into this
+        # sync push as a separate [skip ci] commit when a change is needed.
+        if [[ -n "$PRERELEASE_MANIFEST_FILE" && -n "$STABLE_MANIFEST_FILE" \
+              && "$PRERELEASE_MANIFEST_FILE" != "$STABLE_MANIFEST_FILE" ]]; then
+          echo "🔧 Reconciling prerelease manifest '$PRERELEASE_MANIFEST_FILE'"
+          bash "$GITHUB_ACTION_PATH/reconcile-prerelease-manifest.sh" \
+            "$PRERELEASE_MANIFEST_FILE" "$STABLE_MANIFEST_FILE" "$STABLE_VERSION"
+          if ! git diff --quiet -- "$PRERELEASE_MANIFEST_FILE"; then
+            git add -- "$PRERELEASE_MANIFEST_FILE"
+            git commit \
+              -m "chore: reconcile $TARGET_BRANCH prerelease manifest base [skip ci]" \
+              -m "Reset prerelease cursor(s) to the just-released stable version after promotion to $SOURCE_BRANCH so the next $TARGET_BRANCH release advances correctly." \
+              -m "This commit should not trigger a new release."
+          else
+            echo "✅ Prerelease manifest already reconciled — no extra commit"
+          fi
+        fi
 
         # Push to target branch
         git push origin $TARGET_BRANCH

--- a/.github/actions/sync-branches/reconcile-prerelease-manifest.sh
+++ b/.github/actions/sync-branches/reconcile-prerelease-manifest.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Reconcile a dev (prerelease/beta) release-please manifest against the
+# just-released stable manifest after a stable release reaches `main`.
+#
+# Why this exists
+# ---------------
+# Profile B repos run a dual-track release-please setup with two decoupled
+# manifests:
+#   - prerelease manifest (dev/beta channel, `versioning: prerelease`)
+#   - stable manifest (main channel)
+#
+# When a stable release is cut on `main` (e.g. 0.5.0), only the stable manifest
+# advances. The dev manifest stays at its `X.Y.Z-beta.N` cursor. Because
+# release-please's PrereleaseMinorVersionUpdate only bumps the beta counter
+# while the cursor is a prerelease with patch === 0, the dev base never
+# advances on its own — so new betas (0.5.0-beta.5/.6) end up semver-LOWER than
+# the released stable. This recurs every release cycle.
+#
+# This script strips the prerelease suffix off each dev manifest entry and sets
+# its base to the corresponding just-released stable version, so the next dev
+# release computes correctly (feat -> X.(Y+1).0-beta.1, fix -> X.Y.(Z+1)-beta.1).
+#
+# Safety: an entry is only reset when the dev cursor is a prerelease whose BASE
+# version is <= the stable version. A dev package that legitimately raced ahead
+# of stable (e.g. dev already at 0.6.0-beta.2 while main released 0.5.0) is left
+# untouched — we never downgrade dev.
+#
+# Usage:
+#   reconcile-prerelease-manifest.sh <dev-manifest> <stable-manifest> [single-stable-version]
+#
+# - <dev-manifest>            path to the prerelease manifest (mutated in place)
+# - <stable-manifest>         path to the stable manifest (read-only; may be absent)
+# - [single-stable-version]   fallback stable version for the "." root key when
+#                             no stable manifest entry is found (e.g. the
+#                             release-please release-version output)
+#
+# The dev manifest is mutated in place only when a change is needed. The caller
+# decides whether to commit by inspecting `git diff`. Always exits 0 on success;
+# exits non-zero only on malformed input.
+set -euo pipefail
+
+DEV_MANIFEST="${1:?dev manifest path required}"
+STABLE_MANIFEST="${2:-}"
+SINGLE_STABLE="${3:-}"
+
+if [[ ! -f "$DEV_MANIFEST" ]]; then
+  echo "reconcile: dev manifest '$DEV_MANIFEST' not found — nothing to do"
+  exit 0
+fi
+
+if ! jq empty "$DEV_MANIFEST" 2>/dev/null; then
+  echo "reconcile: dev manifest '$DEV_MANIFEST' is not valid JSON" >&2
+  exit 1
+fi
+
+SEMVER_CORE='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+# Return the lower of two semver core versions (X.Y.Z) using version sort.
+semver_min() {
+  printf '%s\n%s\n' "$1" "$2" | sort -V | head -n1
+}
+
+work=$(mktemp)
+cp "$DEV_MANIFEST" "$work"
+changed=0
+
+# Iterate dev manifest keys (monorepo-safe: one entry per package path).
+while IFS= read -r key; do
+  devv=$(jq -r --arg k "$key" '.[$k]' "$work")
+
+  # Only prerelease cursors need reconciling (must contain a `-` suffix).
+  [[ "$devv" == *-* ]] || continue
+
+  base="${devv%%-*}"
+
+  # Resolve the stable version for this package key.
+  stable=""
+  if [[ -n "$STABLE_MANIFEST" && -f "$STABLE_MANIFEST" ]]; then
+    stable=$(jq -r --arg k "$key" '.[$k] // empty' "$STABLE_MANIFEST")
+  fi
+  if [[ -z "$stable" && "$key" == "." ]]; then
+    stable="$SINGLE_STABLE"
+  fi
+  [[ -n "$stable" ]] || continue
+
+  # Guard against malformed input: only act when both the dev base and the
+  # resolved stable target are plain X.Y.Z cores. This rejects empty/garbage
+  # stable-version passthroughs (never writes an empty string into the
+  # manifest) and keeps `sort -V` comparing well-formed versions only.
+  if ! [[ "$base" =~ $SEMVER_CORE ]]; then
+    echo "reconcile: '$key' dev base '$base' is not a core semver — skipping"
+    continue
+  fi
+  if ! [[ "$stable" =~ $SEMVER_CORE ]]; then
+    echo "reconcile: '$key' stable target '$stable' is not a core semver — skipping"
+    continue
+  fi
+
+  # Never downgrade: skip if the dev base is already ahead of stable.
+  if [[ "$base" != "$stable" && "$(semver_min "$base" "$stable")" == "$stable" ]]; then
+    echo "reconcile: '$key' dev base $base is ahead of stable $stable — leaving $devv untouched"
+    continue
+  fi
+
+  # Already reconciled (cursor equals stable with no suffix would not match the
+  # prerelease guard above, so reaching here means a real change).
+  if [[ "$devv" == "$stable" ]]; then
+    continue
+  fi
+
+  jq --arg k "$key" --arg v "$stable" '.[$k] = $v' "$work" > "$work.next"
+  mv "$work.next" "$work"
+  changed=1
+  echo "reconcile: '$key' $devv -> $stable"
+done < <(jq -r 'keys[]' "$work")
+
+if [[ "$changed" == "1" ]]; then
+  mv "$work" "$DEV_MANIFEST"
+  echo "reconcile: dev manifest '$DEV_MANIFEST' updated"
+else
+  rm -f "$work"
+  echo "reconcile: no changes needed for '$DEV_MANIFEST'"
+fi

--- a/.github/actions/sync-branches/reconcile-prerelease-manifest.test.sh
+++ b/.github/actions/sync-branches/reconcile-prerelease-manifest.test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Self-contained tests for reconcile-prerelease-manifest.sh.
+# Run: .github/actions/sync-branches/reconcile-prerelease-manifest.test.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/reconcile-prerelease-manifest.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+
+# run_case <name> <dev-json> <stable-json|-> <single-version|-> <expected-dev-json>
+run_case() {
+  local name="$1" dev_json="$2" stable_json="$3" single="$4" expected="$5"
+  local dev="$TMP/dev.json" stable="$TMP/stable.json"
+  printf '%s' "$dev_json" > "$dev"
+  local stable_arg=""
+  if [[ "$stable_json" != "-" ]]; then
+    printf '%s' "$stable_json" > "$stable"
+    stable_arg="$stable"
+  else
+    stable_arg="$TMP/does-not-exist.json"
+    rm -f "$stable_arg"
+  fi
+  local single_arg=""
+  [[ "$single" != "-" ]] && single_arg="$single"
+
+  bash "$SCRIPT" "$dev" "$stable_arg" "$single_arg" >/dev/null
+
+  local got expect
+  got="$(jq -S -c . "$dev")"
+  expect="$(printf '%s' "$expected" | jq -S -c .)"
+  if [[ "$got" == "$expect" ]]; then
+    echo "ok   - $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL - $name"
+    echo "       expected: $expect"
+    echo "       got:      $got"
+    fail=$((fail + 1))
+  fi
+}
+
+# 1. The core bug: stuck beta on the same minor line as the released stable.
+run_case "stuck beta resets to stable" \
+  '{".":"0.5.0-beta.5"}' '{".":"0.5.0"}' - '{".":"0.5.0"}'
+
+# 2. Dev legitimately ahead of stable (next minor) — must NOT downgrade.
+run_case "dev ahead not downgraded" \
+  '{".":"0.6.0-beta.2"}' '{".":"0.5.0"}' - '{".":"0.6.0-beta.2"}'
+
+# 3. Dev ahead on patch line — must NOT downgrade.
+run_case "dev patch ahead not downgraded" \
+  '{".":"0.5.1-beta.1"}' '{".":"0.5.0"}' - '{".":"0.5.1-beta.1"}'
+
+# 4. Monorepo: every prerelease entry reconciled from its stable counterpart.
+run_case "monorepo multi-package" \
+  '{".":"0.5.0-beta.3","packages/api":"1.2.0-beta.1"}' \
+  '{".":"0.5.0","packages/api":"1.2.0"}' - \
+  '{".":"0.5.0","packages/api":"1.2.0"}'
+
+# 5. Non-prerelease cursor: no-op.
+run_case "already stable no-op" \
+  '{".":"0.5.0"}' '{".":"0.5.0"}' - '{".":"0.5.0"}'
+
+# 6. Single-version fallback for root when no stable manifest present.
+run_case "single-version fallback for root" \
+  '{".":"0.5.0-beta.5"}' - 0.5.0 '{".":"0.5.0"}'
+
+# 7. Non-root key with no stable entry and no fallback: untouched.
+run_case "non-root no stable entry untouched" \
+  '{"packages/x":"1.0.0-beta.2"}' '{}' - '{"packages/x":"1.0.0-beta.2"}'
+
+# 8. Mixed: one resets, one ahead stays.
+run_case "mixed reset and ahead" \
+  '{".":"0.5.0-beta.4","packages/api":"2.0.0-beta.1"}' \
+  '{".":"0.5.0","packages/api":"1.9.0"}' - \
+  '{".":"0.5.0","packages/api":"2.0.0-beta.1"}'
+
+# 9. Empty stable-version + no stable manifest: must NOT write an empty string.
+run_case "empty stable target no-op" \
+  '{".":"0.5.0-beta.5"}' - - '{".":"0.5.0-beta.5"}'
+
+# 10. JSON null dev value: skipped (no prerelease suffix), untouched.
+run_case "null dev value untouched" \
+  '{".":null}' '{".":"0.5.0"}' - '{".":null}'
+
+# 11. Non-semver dev base: skipped, untouched.
+run_case "non-semver dev base untouched" \
+  '{".":"nightly-beta.1"}' '{".":"0.5.0"}' - '{".":"nightly-beta.1"}'
+
+# 12. Idempotency: running again is a no-op.
+dev="$TMP/idem.json"
+printf '%s' '{".":"0.5.0-beta.5"}' > "$dev"
+stable="$TMP/idem-stable.json"
+printf '%s' '{".":"0.5.0"}' > "$stable"
+bash "$SCRIPT" "$dev" "$stable" >/dev/null
+first="$(jq -S -c . "$dev")"
+bash "$SCRIPT" "$dev" "$stable" >/dev/null
+second="$(jq -S -c . "$dev")"
+if [[ "$first" == '{".":"0.5.0"}' && "$second" == "$first" ]]; then
+  echo "ok   - idempotent"
+  pass=$((pass + 1))
+else
+  echo "FAIL - idempotent (first=$first second=$second)"
+  fail=$((fail + 1))
+fi
+
+echo ""
+echo "passed: $pass  failed: $fail"
+[[ "$fail" -eq 0 ]]

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -1477,6 +1477,13 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token || secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           create-pr: false
           auto-merge-pr: true
+          # Dual-track (Profile B) reconcile: after the stable release lands on
+          # main, reset the dev (beta) prerelease manifest base to the released
+          # stable version so the next dev release stays above stable. No-op
+          # unless both manifests are configured and differ.
+          prerelease-manifest-file: ${{ needs.setup.outputs.release-manifest-file }}
+          stable-manifest-file: ${{ needs.setup.outputs.release-manifest-file-stable }}
+          stable-version: ${{ needs.release.outputs.release-version }}
 
   # =============================================================================
   # PIPELINE SUMMARY — aggregates results into a markdown table AND fails the

--- a/docs/AUTO_SYNC_FEATURE.md
+++ b/docs/AUTO_SYNC_FEATURE.md
@@ -66,6 +66,31 @@ This commit contains version updates and should not trigger a new release.
 
 This ensures the sync commit **won't appear in your next release notes**.
 
+### Dual-track manifest reconciliation (Profile B)
+
+Repos that run a beta stream on `dev` and a stable stream on `main` keep two
+separate release-please manifests (`manifest_file` for dev, `manifest_file_stable`
+for main — see the Versioning Guide). When a stable release is cut on `main`,
+only the stable manifest advances; the dev prerelease manifest stays at its
+`X.Y.Z-beta.N` cursor. Because release-please's prerelease strategy only bumps
+the beta counter while the cursor sits at `patch === 0`, the dev base would
+otherwise never catch up and new betas would compute **lower** than the released
+stable.
+
+During the direct-push sync, the pipeline therefore resets each prerelease
+cursor in `manifest_file` to its just-released stable counterpart (stripping the
+`-beta.N` suffix). This is folded into the sync push as a second `[skip ci]`
+commit:
+
+```
+chore: reconcile dev prerelease manifest base [skip ci]
+```
+
+A package is only reset when its dev base is `<=` the stable version, so a dev
+package that legitimately raced ahead of stable is never downgraded. The
+reconcile is a no-op unless both `manifest_file` and `manifest_file_stable` are
+configured and differ — single-track repos are unaffected.
+
 ## ⚙️ Configuration
 
 ### Enable/Disable Sync


### PR DESCRIPTION
## Systemic fix: auto-reconcile dev prerelease manifest after promotion to main

Closes the recurring drift described in **EDI-376** (parent EDI-372, whose
immediate per-cycle fix shipped manually).

### Problem
Dual-track (Profile B) repos keep two decoupled release-please manifests — a
beta manifest on `dev` (`versioning: prerelease`) and a stable manifest on
`main`. When a stable release is cut on `main` (e.g. `0.5.0`), only the stable
manifest advances; the dev manifest stays at `X.Y.Z-beta.N`. Because
release-please's prerelease strategy only bumps the beta counter while the
cursor sits at `patch === 0`, the dev base never catches up — so new betas
(`0.5.0-beta.5/.6`) compute semver-**lower** than the released stable. This
recurs every release cycle.

### Fix
During the `sync-to-dev` direct-push sync (which already merges `main → dev`
after a stable release), reset each prerelease cursor in the dev manifest to
its just-released stable counterpart (strip `-beta.N`). Folded into the sync
push as a second `[skip ci]` commit:

```
chore: reconcile dev prerelease manifest base [skip ci]
```

The next dev release then advances correctly: `feat → X.(Y+1).0-beta.1`,
`fix → X.Y.(Z+1)-beta.1`.

### Safety
- **Never downgrades.** A package whose dev base is ahead of stable (raced
  ahead on a future minor/patch) is left untouched.
- **No-op unless dual-track.** Runs only when both `manifest_file` and
  `manifest_file_stable` are configured and differ — single-track repos are
  unaffected. The `sync-to-dev` job already gates on `release-created == true`
  on `refs/heads/main`, so non-release pushes never trigger it.
- **Validated input.** Both the dev base and the resolved stable target must be
  plain `X.Y.Z` cores, so an empty/malformed stable version is never written
  into the manifest. JSON `null` / non-prerelease cursors are skipped.

### Scope
- `.github/actions/sync-branches/action.yaml` — new optional inputs
  (`prerelease-manifest-file`, `stable-manifest-file`, `stable-version`) +
  reconcile in the direct-push path.
- `.github/actions/sync-branches/reconcile-prerelease-manifest.sh` — standalone,
  pure, in-place reconcile (monorepo-safe).
- `.github/actions/sync-branches/reconcile-prerelease-manifest.test.sh` —
  **12 cases**, all passing locally (stuck beta, no-downgrade, monorepo, mixed,
  fallback, null/non-semver/empty-target guards, idempotency).
- `.github/workflows/universal-pipeline.yaml` — wire the three inputs from the
  `sync-to-dev` job.
- `docs/AUTO_SYNC_FEATURE.md` — document dual-track reconciliation.

### Verification
`bash reconcile-prerelease-manifest.test.sh` → `passed: 12 failed: 0`. YAML
parses; bash `-n` clean. The core bug case (`0.5.0-beta.5` + stable `0.5.0` →
`0.5.0`) and the no-downgrade case (`0.6.0-beta.2` + stable `0.5.0` → unchanged)
are both covered.

### Codex (GPT-5) crosscheck — **concerns addressed**
One-pass crosscheck flagged: empty/non-semver values reaching `sort -V` and a
possible empty-string write → **fixed** with a core-semver validation guard +
3 new tests. Other notes were either already handled (`$GITHUB_ACTION_PATH` is
quoted; JSON `null` skipped by the `*-*` prerelease guard) or pre-existing in
the original sync-branches design (push non-fast-forward race — not a
regression, this change adds no extra push). No blockers.

Refs: EDI-376
