### PR TITLE
fix(ci): grant static-checks checks:write for trunk annotations (EDI-669)

### DIFF
--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -124,8 +124,8 @@ on:
 
 # NOTE: Calling workflows must grant the permissions each job actually uses:
 #   setup:     contents: read, pull-requests: read (PR Files API for docs-only detection)
-#   security:  contents: read, pull-requests: write
-#   lint/test: contents: read
+#   security:      contents: read, pull-requests: write
+#   static-checks: contents: read, pull-requests: write, checks: write (trunk-action check annotations)
 #   build:     contents: read, id-token: write, attestations: write
 #   deploy:    contents: read, deployments: write, pull-requests: write, packages: write, id-token: write
 #   release:   contents: write, pull-requests: write, id-token: write
@@ -656,6 +656,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      checks: write # trunk-action posts lint results as check annotations (Checks API); without this it logs "Failed to post annotations to github: 403"
     needs: setup
     if: |
       (needs.setup.outputs.enable-security == 'true' || needs.setup.outputs.enable-lint == 'true') &&


### PR DESCRIPTION
## What
Adds `checks: write` to the reusable pipeline's `static-checks` job permissions.

## Why
Part of [EDI-669](/EDI/issues/EDI-669) hardening. `trunk-io/trunk-action` posts lint results as GitHub **check annotations** via the Checks API. The job only granted `contents: read` + `pull-requests: write`, so the annotation POST failed with `Failed to post annotations to github: 403` (observed across edilio PRs in EDI-668). The 403 is cosmetic today (the real red is the lint/fmt exit code, not the annotation post) but it clutters logs and could compound.

## Caller pairing
Reusable-workflow jobs are capped by the caller's granted permissions. Caller workflows that want trunk annotations must also add `checks: write` at the workflow level. A companion edilio PR does this for `edilio/.github/workflows/ci.yaml`. Takes effect for edilio once the `v3` tag advances (release-please).

Co-Authored-By: Paperclip <noreply@paperclip.ing>