### PR TITLE
fix(release-management): set versioning-strategy on prerelease branches

### DIFF
--- a/.github/actions/release-management/action.yaml
+++ b/.github/actions/release-management/action.yaml
@@ -143,7 +143,7 @@ runs:
         set -euo pipefail
         echo "Injecting prerelease config into $CONFIG_FILE"
         tmp=$(mktemp)
-        jq --arg ptype "$PRERELEASE_TYPE" '. + {"prerelease": true, "prerelease-type": $ptype}' "$CONFIG_FILE" > "$tmp"
+        jq --arg ptype "$PRERELEASE_TYPE" '. + {"prerelease": true, "prerelease-type": $ptype, "versioning-strategy": "prerelease"}' "$CONFIG_FILE" > "$tmp"
         mv "$tmp" "$CONFIG_FILE"
         echo "Updated config:"
         cat "$CONFIG_FILE"


### PR DESCRIPTION
## Summary

`.github/actions/release-management/action.yaml` (Inject prerelease config step) only injects `prerelease` + `prerelease-type`. In release-please 17.1.3 those two keys only mark the **GitHub release** as a prerelease — the version bump itself is owned by `versioning-strategy`, which defaults to `DefaultVersioningStrategy` and never reads `prerelease-type`. Only `PrereleaseVersioningStrategy` appends the `-beta`/`-alpha`/`-rc` label.

Result: **every** repo configuring `release.prerelease_branches` in `.github/pipeline.yaml` cut **stable** versions on its prerelease branch. Root cause of the `platzl-finder` `:latest` freeze — see PRI-603 / PRI-605. Worked around repo-locally in `maxbec/platzl-finder` PR #71 by setting `versioning-strategy: prerelease` directly; this PR fixes it upstream so repos don't need the local override.

## Change

Add `"versioning-strategy": "prerelease"` to the same root-level jq injection, so release-please's `mergeConfig` propagates it into every package alongside the existing `prerelease`/`prerelease-type` keys.

## Notes for reviewer

- This repo (`navigaite/.github`) is Profile A (feature → `main`, no `dev` branch) per its own `AGENTS.md` §7/§10 — targeting `main` here is correct, not a policy violation.
- Callers pin `@v3`. This PR alone does not move that tag — the subsequent release-please PR on `main` (which cuts the stable release and moves `@v3`) is board-only per the GitHub Change Flow policy; I will not merge it.

## Test plan

- [x] No existing automated test covers this injection step (checked `.github/workflows/*`, no fixture for `inject-prerelease`).
- [ ] Post-merge, once `@v3` moves: a prerelease-branch repo (e.g. `platzl-finder` `dev`) cuts a `-beta.N` version without its repo-local `versioning-strategy` override.

PRI-613