### PR TITLE
feat(pipeline): add runner.labels opt-in for self-hosted runners

### DIFF
--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -161,6 +161,9 @@ jobs:
       package-manager: ${{ steps.setup-env.outputs.package-manager }}
       enable-caching: ${{ steps.parse-config.outputs.enable-caching }}
 
+      # Runner targeting (self-hosted opt-in, defaults to ubuntu-latest)
+      runner-labels: ${{ steps.parse-config.outputs.runner-labels }}
+
       # Pipeline configuration
       enable-security: ${{ steps.parse-config.outputs.enable-security }}
       enable-trufflehog: ${{ steps.parse-config.outputs.enable-trufflehog }}
@@ -239,6 +242,7 @@ jobs:
             # Set sensible defaults
             CONFIGURED_STACK="auto"
             ENABLE_CACHING="true"
+            RUNNER_LABELS='["ubuntu-latest"]'
             RUNTIME_NODE_VERSION=""
             RUNTIME_PYTHON_VERSION=""
             RUNTIME_FLUTTER_VERSION=""
@@ -298,6 +302,12 @@ jobs:
             # Parse configuration using yq
             CONFIGURED_STACK=$(yq -r '.stack // "auto"' "$CONFIG_FILE")
             ENABLE_CACHING=$(yq '.pipeline.enable_caching // true' "$CONFIG_FILE")
+            # Self-hosted opt-in. Labels are only meaningful if a runner is
+            # actually registered against THIS repo (runners are repo-scoped),
+            # so an unrelated repo setting these labels just queues forever —
+            # there is no cross-repo execution risk from this being a shared,
+            # public workflow file.
+            RUNNER_LABELS=$(yq -o=json -I=0 '.runner.labels // ["ubuntu-latest"]' "$CONFIG_FILE" | jq -c '.')
             RUNTIME_NODE_VERSION=$(yq -r '.runtime.node_version // ""' "$CONFIG_FILE")
             RUNTIME_PYTHON_VERSION=$(yq -r '.runtime.python_version // ""' "$CONFIG_FILE")
             RUNTIME_FLUTTER_VERSION=$(yq -r '.runtime.flutter_version // ""' "$CONFIG_FILE")
@@ -427,6 +437,7 @@ jobs:
           # Output configuration
           echo "configured-stack=$CONFIGURED_STACK" >> $GITHUB_OUTPUT
           echo "enable-caching=$ENABLE_CACHING" >> $GITHUB_OUTPUT
+          echo "runner-labels=$RUNNER_LABELS" >> $GITHUB_OUTPUT
           echo "runtime-node-version=$RUNTIME_NODE_VERSION" >> $GITHUB_OUTPUT
           echo "runtime-python-version=$RUNTIME_PYTHON_VERSION" >> $GITHUB_OUTPUT
           echo "runtime-flutter-version=$RUNTIME_FLUTTER_VERSION" >> $GITHUB_OUTPUT
@@ -651,7 +662,7 @@ jobs:
   # =============================================================================
   static-checks:
     name: 🔎 Static Checks
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.setup.outputs.runner-labels) }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -898,7 +909,7 @@ jobs:
   # =============================================================================
   verify:
     name: 🧪 Verify
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.setup.outputs.runner-labels) }}
     timeout-minutes: 45
     permissions:
       contents: read
@@ -1199,7 +1210,7 @@ jobs:
 
   deploy-docker:
     name: 🐳 Docker / ${{ matrix.image.name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.setup.outputs.runner-labels) }}
     timeout-minutes: 20
     permissions:
       contents: read

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -242,6 +242,29 @@ When a pull request changes only files matching `**/*.md`, `**/*.mdx`, `docs/**`
 
 ---
 
+### `runner` (optional)
+
+**Type:** `object`
+
+Opt into a self-hosted runner for the `static-checks`, `verify`, and `deploy-docker` jobs. `setup`, `release`, and `sync-to-dev` always run on `ubuntu-latest`.
+
+#### `runner.labels`
+
+**Type:** `array` **Default:** `["ubuntu-latest"]`
+
+```yaml
+runner:
+  labels: [self-hosted, mainz-homelab]
+```
+
+Labels are matched against runners registered directly to *this* repository (runners are repo-scoped, not org-scoped here). If no runner with these labels is registered against the repo, the job just queues — there is no cross-repo execution risk from this field living in a shared, public workflow file.
+
+Only point this at a self-hosted runner on a **private** repo. A public repo's self-hosted runner would let an untrusted fork PR execute arbitrary code on that hardware — never set `runner.labels` to anything but `ubuntu-latest` (the default) on a public repo.
+
+See the Mainz homelab runner (labels: `self-hosted, mainz-homelab, linux, x64, docker`) — [PRI-625] for setup and rollback.
+
+---
+
 ### `security` (optional)
 
 **Type:** `object`


### PR DESCRIPTION
## Summary
- Adds a `runner.labels` field to `pipeline.yaml` (default `["ubuntu-latest"]`), parsed in the `setup` job and threaded into `runs-on` for `static-checks`, `verify`, and `deploy-docker` via `fromJSON(needs.setup.outputs.runner-labels)`.
- Backward compatible: repos with no `runner:` config are unaffected (still `ubuntu-latest`).
- Documents the field in `docs/CONFIGURATION.md`, including the security invariant: runners are repo-scoped, so this being a shared/public workflow file creates no cross-repo execution path — an unrelated repo requesting these labels simply has no matching runner and the job queues.

## Context
Part of [PRI-625](/PRI/issues/PRI-625) — durable fix for the exhausted GitHub Actions minutes ([PRI-623](/PRI/issues/PRI-623)). A self-hosted runner (`myoung34/github-runner`, ephemeral, resource-capped) is already live on the Mainz homelab and registered against `maxbec/platzl-finder`, verified with a real green job (`runner_name: mainz-homelab-platzl-finder`). This PR is the piece that lets `pipeline.yaml` actually target it instead of every consumer hand-editing `runs-on:` in their own caller workflow.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`) — jobs list unchanged.
- [x] Manual review: only `static-checks`/`verify`/`deploy-docker` runs-on changed; `setup`/`release`/`sync-to-dev` stay on `ubuntu-latest` intentionally.
- [ ] CI (Check Gate / Branch Guard) on this PR — public repo, unaffected by the private-repo Actions-minutes exhaustion.
- [ ] Follow-up: opt `platzl-finder`'s `pipeline.yaml` into `runner.labels: [self-hosted, mainz-homelab]` and confirm a real pipeline run (not just the smoke test) goes green on the homelab runner — tracked as a PRI-625 sub-step, will reference this PR's merged SHA/tag.

## Note on merge
I authored this substantially, so per the four-eyes convention I'm not merging it myself. `navigaite/.github` has no `dev` branch (established practice here is feature → `main` directly, release-please cuts stable from `main`) — flagging that explicitly since every other repo uses the two-branch model. Handing to CTO for review + merge given the blast radius (every private repo's pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)