### PR TITLE
fix(hmac-cron-post): harden against 3xx false-green + caller audit (PRI-633)

### DIFF
--- a/.github/workflows/hmac-cron-post.yaml
+++ b/.github/workflows/hmac-cron-post.yaml
@@ -60,8 +60,26 @@ jobs:
           SIG=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$CRON_HMAC_KEY" -hex | awk '{print $2}')
 
           echo "POSTing to ${CRON_BASE_URL}${ENDPOINT} at $TS"
-          curl --fail-with-body --silent --show-error -X POST \
+
+          # No -L: following a redirect (e.g. to an auth wall) is not success,
+          # and the signed path would no longer match the requested path,
+          # breaking HMAC verification. We capture the status code explicitly
+          # instead of relying on --fail-with-body, which only trips on >= 400
+          # and lets a 3xx (redirect to a login/auth-wall page) exit 0.
+          HTTP_CODE=$(curl --silent --show-error -o /tmp/cron-response.txt -w '%{http_code}' -X POST \
             "${CRON_BASE_URL}${ENDPOINT}" \
             -H "X-Cron-Timestamp: $TS" \
             -H "X-Cron-Nonce: $NONCE" \
-            -H "X-Cron-Signature: $SIG"
+            -H "X-Cron-Signature: $SIG")
+
+          BODY_PREVIEW=$(head -c 500 /tmp/cron-response.txt || true)
+
+          echo "Response: HTTP $HTTP_CODE"
+          echo "Body (truncated to 500 bytes): $BODY_PREVIEW"
+
+          if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+            echo "::error::Cron POST to ${CRON_BASE_URL}${ENDPOINT} returned HTTP $HTTP_CODE (expected 2xx). Not following redirects — a 3xx here usually means an auth wall (e.g. Cloudflare Access) intercepted the request before it reached the app."
+            exit 1
+          fi
+
+          echo "Cron POST succeeded with HTTP $HTTP_CODE"


### PR DESCRIPTION
## Summary
- `hmac-cron-post.yaml` used `curl --fail-with-body`, which only trips on HTTP `>=400`. A `3xx` (e.g. Cloudflare Access redirecting to a login page) exited `0` and the job reported success while the request never reached the app.
- Fix: capture the HTTP status explicitly (`-o body -w '%{http_code}'`) and fail on anything outside `2xx`. Echo status code + truncated (500B) response body on both success and failure paths so a future silent failure is visible in the log.
- No `-L` added — following a redirect to an auth wall is not success, and the signed path would no longer match the requested path, breaking HMAC verification (per issue guidance).

## Caller audit (org-wide, `gh search code`)
Only 3 callers exist anywhere in the `navigaite` org, all in `navigaite/edilio`, all pinned `@v2`:

| Caller | Endpoint | Status |
|---|---|---|
| `cron-dunning.yml` | `/api/cron/dunning` | **Dead** — every run 302→CF Access, reports green |
| `cron-feedback-comments.yml` | `/api/cron/feedback-comments` | **Dead** — every run 302→CF Access, reports green |
| `cron-recurring-invoices.yml` | `/api/cron/recurring-invoices` | **Dead** — every run 302→CF Access, reports green |

All three point `CRON_BASE_URL` at `https://app-staging.edilio.de` (CF Access gated). Verified via `gh run view --log` on the latest run of each — all show `302 Found` in the body, all `conclusion: success`. No other repo in the org references this reusable workflow. edilio is already migrating off it per PRI-629; this fix protects any other repo that may point at an auth-gated origin in future, and makes the edilio dead-cron state visible in logs going forward (formerly invisible).

Full findings posted on [PRI-633](/PRI/issues/PRI-633).

## Note on branch target
This repo (`navigaite/.github`) has no `dev` branch — every existing merged/open PR here targets `main` directly (checked: #196, #197-201, #202). Targeting `main` here matches established repo convention, not the two-branch feature→dev promotion flow. Flagging per policy that "a repo lacking `dev` is a migration task, not a license to merge to main" — leaving the merge decision to review rather than self-merging.

## Test plan
Actions minutes are exhausted (PRI-623 interim policy) — pipeline cannot run. Per policy, local proof substitutes:
- `actionlint` clean (see `LOCAL-CI:` comment below)
- Extracted embedded shell, `bash -n` syntax-checked
- Ran the extracted script against a local mock server returning `302` → script exits `1`, error logged
- Ran it again against a mock server returning `200` → script exits `0`, success logged
- The `workflow_dispatch` red-run proof against a real redirecting origin (per Acceptance Criteria) is deferred to after the ~2026-08-01 Actions minutes reset, as the issue itself anticipates.

🤖 Generated with Claude Code