### PR TITLE
fix(release): read prerelease config from branch, not runner disk

### DIFF
--- a/.github/actions/release-management/action.yaml
+++ b/.github/actions/release-management/action.yaml
@@ -132,21 +132,109 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Inject prerelease config
-      id: inject-prerelease
+    # Prerelease settings CANNOT be injected at runtime. release-please-action
+    # calls Manifest.fromManifest(github, targetBranch, configFile, ...), which
+    # fetches the config file over the GitHub API from the tip of the target
+    # branch — it never reads the runner's checked-out copy. A previous version
+    # of this step rewrote the local file with jq; the edit was silently
+    # discarded and every prerelease branch kept cutting stable versions
+    # (PRI-662). The keys must therefore be COMMITTED to the config file that
+    # release.config_file points at.
+    #
+    # This step verifies that, against the same source release-please reads, and
+    # fails loudly when the keys are missing. Silent stable releases on a beta
+    # branch are far more expensive than a red pipeline.
+    - name: Verify prerelease config
+      id: verify-prerelease
       if: inputs.strategy == 'release-please' && inputs.config-file != '' && inputs.prerelease == 'true'
       shell: bash
       env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        API_URL: ${{ github.api_url }}
+        REPO: ${{ github.repository }}
         CONFIG_FILE: ${{ inputs.config-file }}
+        TARGET_BRANCH: ${{ inputs.target-branch || github.ref_name }}
         PRERELEASE_TYPE: ${{ inputs.prerelease-type }}
       run: |
         set -euo pipefail
-        echo "Injecting prerelease config into $CONFIG_FILE"
-        tmp=$(mktemp)
-        jq --arg ptype "$PRERELEASE_TYPE" '. + {"prerelease": true, "prerelease-type": $ptype, "versioning-strategy": "prerelease"}' "$CONFIG_FILE" > "$tmp"
-        mv "$tmp" "$CONFIG_FILE"
-        echo "Updated config:"
-        cat "$CONFIG_FILE"
+
+        # curl, not `gh` — the self-hosted runners do not ship the gh CLI.
+        echo "Reading $CONFIG_FILE from $REPO@$TARGET_BRANCH (the source release-please itself reads)"
+        if ! config=$(curl -sSfL \
+          -H "Authorization: Bearer $GH_TOKEN" \
+          -H "Accept: application/vnd.github.raw+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "$API_URL/repos/$REPO/contents/$CONFIG_FILE?ref=$TARGET_BRANCH"); then
+          echo "::error::Could not read $CONFIG_FILE from $REPO@$TARGET_BRANCH. Does release.config_file point at a file committed on that branch?"
+          exit 1
+        fi
+
+        if ! echo "$config" | jq empty 2>/dev/null; then
+          echo "::error::$CONFIG_FILE on $TARGET_BRANCH is not valid JSON."
+          exit 1
+        fi
+
+        # Root-level keys act as defaults for every package entry
+        # (manifest.ts: `pathConfig.versioning ?? defaultConfig.versioning`),
+        # so a key set at either level counts as present.
+        read_key() {
+          echo "$config" | jq -r --arg k "$1" \
+            '[.[$k]] + [(.packages // {} | to_entries[] | .value[$k])]
+             | map(select(. != null)) | first // "«unset»"'
+        }
+
+        versioning=$(read_key versioning)
+        prerelease=$(read_key prerelease)
+        ptype=$(read_key prerelease-type)
+
+        echo "  versioning      = $versioning"
+        echo "  prerelease      = $prerelease"
+        echo "  prerelease-type = $ptype"
+
+        errors=0
+
+        # The release-please config key is `versioning`. `versioning-strategy`
+        # is NOT a recognised key — release-please ignores it without warning
+        # and falls back to the `default` strategy, producing stable versions.
+        if echo "$config" | grep -q '"versioning-strategy"'; then
+          echo "::error::$CONFIG_FILE uses \"versioning-strategy\", which release-please does not recognise. Rename it to \"versioning\"."
+          errors=1
+        fi
+
+        if [[ "$versioning" != "prerelease" ]]; then
+          echo "::error::$CONFIG_FILE must set \"versioning\": \"prerelease\" (found: $versioning)."
+          errors=1
+        fi
+
+        # PrereleaseVersioningStrategy.determineReleaseType() strips the
+        # prerelease suffix unless `prerelease` is exactly true, so the
+        # versioning strategy alone still yields a stable version.
+        if [[ "$prerelease" != "true" ]]; then
+          echo "::error::$CONFIG_FILE must set \"prerelease\": true (found: $prerelease)."
+          errors=1
+        fi
+
+        if [[ -n "$PRERELEASE_TYPE" && "$ptype" != "$PRERELEASE_TYPE" ]]; then
+          echo "::error::$CONFIG_FILE must set \"prerelease-type\": \"$PRERELEASE_TYPE\" to match the pipeline.yaml prerelease_branches label (found: $ptype)."
+          errors=1
+        fi
+
+        if [[ "$errors" -ne 0 ]]; then
+          echo ""
+          echo "Branch '$TARGET_BRANCH' is configured as a prerelease branch, but"
+          echo "$CONFIG_FILE on that branch would make release-please cut a STABLE"
+          echo "version. Commit these keys to $CONFIG_FILE (root level is fine):"
+          echo ""
+          echo "  \"versioning\": \"prerelease\","
+          echo "  \"prerelease\": true,"
+          echo "  \"prerelease-type\": \"${PRERELEASE_TYPE:-beta}\""
+          echo ""
+          echo "Keep them OUT of the stable config (release.config_file_stable),"
+          echo "or main will cut prereleases too."
+          exit 1
+        fi
+
+        echo "✓ Prerelease config verified — release-please will cut ${PRERELEASE_TYPE:-prerelease} versions."
 
     - name: Run Release Please (manifest mode)
       id: release-please-manifest

--- a/.github/release-please-config.dev.json
+++ b/.github/release-please-config.dev.json
@@ -5,7 +5,7 @@
   "include-v-in-tag": true,
   "prerelease": true,
   "prerelease-type": "beta",
-  "versioning-strategy": "prerelease",
+  "versioning": "prerelease",
   "packages": {
     ".": {
       "component": "",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -729,6 +729,40 @@ prerelease_branches:
     label: beta
 ```
 
+> **This setting alone does not produce prereleases.** It tells the pipeline
+> which branch is a prerelease branch and which manifest/config pair to use, but
+> the actual version shape is decided by `release-please` from its own config
+> file. `release-please-action` fetches that file over the GitHub API from the
+> tip of the target branch — it never reads the runner's checked-out copy — so
+> the keys below must be **committed** to the file `release.config_file` points
+> at:
+>
+> ```json
+> {
+>   "versioning": "prerelease",
+>   "prerelease": true,
+>   "prerelease-type": "beta"
+> }
+> ```
+>
+> Root level is fine; root values are inherited as defaults by every entry in
+> `packages`.
+>
+> Two traps, both of which fail **silently** as stable releases:
+>
+> - The key is `versioning`, **not** `versioning-strategy`. `release-please`
+>   ignores unknown keys without warning and falls back to the `default`
+>   strategy.
+> - `"prerelease": true` is required in addition to the versioning strategy.
+>   Without it, `PrereleaseVersioningStrategy` strips the prerelease suffix and
+>   emits a plain `x.y.z`.
+>
+> Keep all three keys **out** of `release.config_file_stable`, or `main` will
+> cut prereleases too.
+>
+> The `release-management` action verifies this against the target branch before
+> invoking `release-please` and fails the pipeline if the keys are missing.
+
 ---
 
 ## 📋 Minimal Configuration Examples


### PR DESCRIPTION
Fixes the reason every `prerelease_branches` repo keeps cutting **stable** versions on `dev` instead of beta.

## Root cause — three defects, not one

**1. The injection never reached release-please (the filed bug).**
`Inject prerelease config` rewrote the runner's checked-out copy of the config with `jq`, then invoked `googleapis/release-please-action@v4.4.0`. That action calls `Manifest.fromManifest(github, targetBranch, configFile, manifestFile)` ([`src/index.ts:118`](https://github.com/googleapis/release-please-action/blob/v4/src/index.ts#L118)), which fetches the config **over the GitHub API from the tip of the target branch**. The local edit was discarded every run.

**2. The key it wrote does not exist.**
It wrote `"versioning-strategy"`. release-please's key is **`"versioning"`** — confirmed in `manifest.ts` (`versioning: config['versioning']`) and `schemas/config.json`, in every release-please version `v4.4.0` could resolve (it depends on `release-please@^17.1.3`; checked v16.0.0 / v16.12.0 / v17.0.0). Unknown keys are ignored without warning, so the strategy stayed `default` — which is exactly what the platzl-finder run log printed.

**3. `versioning` alone is still not enough.**
`PrereleaseVersioningStrategy.determineReleaseType()` ends with `if (!this.prerelease) { ...return plain major.minor.patch }` — without `"prerelease": true` the suffix is stripped and you get a stable version anyway.

So `platzl-finder#74`, which committed `"versioning-strategy": "prerelease"`, was a no-op. **This repo has the same typo**, which is why `dev` released `3.2.0` stable instead of `3.2.0-beta.1`.

## Change

- **Delete** the injection step. It cannot work by design.
- **Add** a `Verify prerelease config` preflight that reads the config from the *same source release-please reads* (target-branch API) and fails the pipeline when `versioning` / `prerelease` / `prerelease-type` are missing or when the `versioning-strategy` typo is present. A misconfigured prerelease branch now turns **red** instead of silently shipping a stable release.
- Fix `.github/release-please-config.dev.json`: `versioning-strategy` -> `versioning`.
- Document the three required keys and both silent-failure traps in `docs/CONFIGURATION.md`.

## Verification performed before opening

- `curl` call dry-run against the live API for both `maxbec/platzl-finder@dev` and `navigaite/.github@dev` — returns raw JSON, parses.
- Negative path: missing file -> `curl -sSfL` exits 22 -> step fails with an actionable message.
- `jq` key-resolution logic run against three real configs: platzl-finder `dev` (broken -> all `«unset»`, correctly rejected), platzl-finder `main` (stable -> all unset, correctly untouched), this repo's fixed dev config (-> `prerelease` / `true` / `beta`, correctly accepted).
- Uses `curl`, not `gh` — verified the self-hosted `mainz-homelab` runner host has `curl` and `jq` but **no** `gh`.
- `action.yaml` parses as YAML (7 steps); `bash -n` clean on the new script; `jq empty` clean on the config.

## Follow-up (not in this PR)

`maxbec/platzl-finder`'s `dev` config needs the same three keys, and its release PR #75 (`chore(dev): release 1.46.0`, stable) must not be merged. Tracked separately.

Refs PRI-662, PRI-603, PRI-605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)