### PR TITLE
ci: skip Branch Guard on dev-targeted PRs (PRI-630)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,20 @@ jobs:
   # there). PRs targeting main must be one of: a promotion from dev, an
   # automated release-please PR, or an emergency hotfix/* — mirrors the
   # pattern other two-branch repos (e.g. edilio) already run.
+  #
+  # The `if:` also gates on `base.ref == 'main'` (PRI-630). Every code path in
+  # the step below exits 0 immediately when the base is not `main`, so running
+  # the job on dev-targeted PRs burned a full billed minute to print
+  # "PR targets dev — allowed". Skipping it instead costs zero minutes and
+  # satisfies the `Branch Guard` required status check exactly as before —
+  # GitHub treats an `if:`-skipped job as passing, which this job already
+  # relied on for non-PR events (see run 29674631690, where a skipped
+  # Branch Guard merged cleanly). `base.ref` is set by GitHub, not the PR
+  # author, so it cannot be spoofed from a fork.
   # ---------------------------------------------------------------------------
   branch-guard:
     name: Branch Guard
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:


### PR DESCRIPTION
## What

Gate the `Branch Guard` job on `github.event.pull_request.base.ref == 'main'`.

## Why

[PRI-630](https://github.com/navigaite/.github) — second half of the orchestration-job fold. The PRI-626 census measured `Branch Guard` at **111 runs, 4s average, 111 billed minutes, 103 wasted**. Every one of those runs on a dev-targeted PR did nothing but print `✅ PR targets dev — allowed` and exit 0.

## Why not the originally scoped fold

PRI-630 originally scoped "fold Branch Guard into 🔧 Setup & Configuration". That is not safely achievable:

- `Branch Guard` is a **required status check** in the repo rulesets (`Protected branches`, id 13405188 → `[{"context":"Check Gate"},{"context":"Branch Guard"}]`), and in the org rulesets too.
- Moving the logic into the reusable workflow's `setup` job destroys the `Branch Guard` check name, so every ruleset in the org and in every caller repo would have to be edited in the same change or **every open PR fleet-wide deadlocks** on a check that will never report.

This change reaches the same billed-minute outcome with **zero ruleset edits** and no deadlock surface.

## Safety

- Coverage unchanged. The skipped path is exactly the `if [[ "$PR_BASE" != "main" ]]; then … exit 0` path.
- `base.ref` is populated by GitHub, not the PR author — it cannot be spoofed from a fork. The fork-spoofing guard inside the step still runs on every `main`-targeted PR, which is the only place it mattered.
- A skipped job **satisfies** a required status check. This job already relies on that: it skips on every non-PR event, and [edilio run 29674631690](https://github.com/navigaite/edilio/actions/runs/29674631690) shows `Branch Guard | skipped` on a release-please PR that merged cleanly.
- Fully reversible — revert the one-line `if:`.

## Canary

This repo is the canary per the PRI-630 constraint. Once a dev PR here is proven to still gate correctly, the same one-liner rolls out to the four other callers that define `branch-guard` in their own `ci.yaml`.

Refs PRI-630, PRI-626.