### PR TITLE
perf(ci): skip deploy jobs on empty matrix — stop phantom runners (PRI-721 Scope A)

### DIFF
--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -1089,6 +1089,7 @@ jobs:
       needs.setup.outputs.enable-deploy == 'true' &&
       needs.setup.outputs.deploy-provider == 'vercel' &&
       needs.setup.outputs.docs-only != 'true' &&
+      needs.setup.outputs.deploy-environments != '[]' &&
       (needs.static-checks.result == 'success' || needs.static-checks.result == 'skipped') &&
       (needs.verify.result == 'success' || needs.verify.result == 'skipped')
     strategy:
@@ -1199,6 +1200,7 @@ jobs:
       needs.setup.outputs.enable-deploy == 'true' &&
       needs.setup.outputs.deploy-provider == 'digitalocean' &&
       needs.setup.outputs.docs-only != 'true' &&
+      needs.setup.outputs.deploy-environments != '[]' &&
       (needs.static-checks.result == 'success' || needs.static-checks.result == 'skipped') &&
       (needs.verify.result == 'success' || needs.verify.result == 'skipped')
     strategy:
@@ -1241,6 +1243,7 @@ jobs:
       needs.setup.outputs.enable-deploy == 'true' &&
       needs.setup.outputs.deploy-provider == 'docker' &&
       needs.setup.outputs.docs-only != 'true' &&
+      needs.setup.outputs.docker-images != '[]' &&
       (needs.static-checks.result == 'success' || needs.static-checks.result == 'skipped') &&
       (needs.verify.result == 'success' || needs.verify.result == 'skipped') &&
       (needs.release.result == 'success' || needs.release.result == 'skipped')


### PR DESCRIPTION
## What

Scope A of [PRI-721](https://.../PRI-721). Suppresses the empty-matrix phantom runners in the universal pipeline's three deploy jobs.

`deploy-vercel`, `deploy-digitalocean` and `deploy-docker` each gate on `enable-deploy` + `deploy-provider`, but their matrix source (`deploy-environments` / `docker-images`) can be filtered to `[]` for a given event/branch. When the `if:` passed while the matrix was empty, GitHub booked a **placeholder runner** — the job appears in the API with its raw, un-expanded name `🚀 Vercel / ${{ matrix.environment }}` and burns one full billed minute doing nothing.

The PRI-626 minute audit measured this 30× over 2026-07-01→19 (~46 min/month).

## Change

Add a non-empty guard to each deploy job's `if:`:
- vercel / digitalocean → `needs.setup.outputs.deploy-environments != '[]'`
- docker → `needs.setup.outputs.docker-images != '[]'`

`setup` emits these outputs as compact JSON (`jq -c`), so empty = literal `[]`. With the guard false, the job is cleanly **skipped** (free, filtered out of the PRI-626 count) instead of phantom-booked. The guard is true whenever there is any real environment/image, so **no behaviour change for actual deploys**.

## Guardrails honoured

No test deleted/skipped/weakened, no threshold lowered, no required check touched. Runner allocation only.

## Verification

- `python3 yaml.safe_load` parses clean.
- Pipeline lint (actionlint) runs on this PR.
- Post-merge live check per PRI-626 method (one `pull_request` + one `push` run on `navigaite/edilio`, `skipped` excluded, round up per job) tracked on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)