### PR TITLE
fix: land NAV-21 audit fixes to the universal pipeline

### DIFF
--- a/.github/actions/deploy-coolify/action.yaml
+++ b/.github/actions/deploy-coolify/action.yaml
@@ -123,7 +123,9 @@ runs:
           done
 
           echo "deployment-status=timeout" >> $GITHUB_OUTPUT
-          echo "::warning::Deployment did not complete within ${TIMEOUT}s"
+          echo "::error::Deployment did not reach 'running' within ${TIMEOUT}s (repeated status-check errors or a stuck deploy). Failing the job."
+          echo "::endgroup::"
+          exit 1
         else
           echo "deployment-status=triggered" >> $GITHUB_OUTPUT
           echo "Deployment triggered, not waiting for completion"

--- a/.github/actions/run-build/action.yaml
+++ b/.github/actions/run-build/action.yaml
@@ -125,7 +125,15 @@ runs:
           # Auto-detect and run appropriate build
           case "$STACK" in
             nodejs)
-              if command -v jq &> /dev/null && [[ -f "package.json" ]]; then
+              # jq is required to read package.json scripts. If it is missing,
+              # the old `if command -v jq && ...` guard silently skipped the
+              # build and the step passed as a no-op — dangerous on self-hosted
+              # runner images that may not ship jq. Fail hard instead.
+              if ! command -v jq &> /dev/null; then
+                echo "::error::jq is required to detect the Node.js build script but is not installed on this runner. Add jq to the runner image."
+                exit 1
+              fi
+              if [[ -f "package.json" ]]; then
                 HAS_BUILD=$(jq -r '.scripts.build // empty' package.json)
 
                 if [[ -n "$HAS_BUILD" ]]; then
@@ -134,6 +142,8 @@ runs:
                 else
                   echo "::warning::No build script found in package.json, skipping build"
                 fi
+              else
+                echo "::warning::No package.json found, skipping build"
               fi
               ;;
 

--- a/.github/actions/run-lint/action.yaml
+++ b/.github/actions/run-lint/action.yaml
@@ -62,8 +62,16 @@ runs:
           # Auto-detect and run appropriate linter
           case "$STACK" in
             nodejs)
+              # jq is required to read package.json scripts. If it is missing,
+              # the old `if command -v jq && ...` guard silently skipped linting
+              # and the step passed as a no-op — dangerous on self-hosted runner
+              # images that may not ship jq. Fail hard instead.
+              if ! command -v jq &> /dev/null; then
+                echo "::error::jq is required to detect Node.js lint scripts but is not installed on this runner. Add jq to the runner image."
+                exit 1
+              fi
               # Check for common linting scripts in package.json
-              if command -v jq &> /dev/null && [[ -f "package.json" ]]; then
+              if [[ -f "package.json" ]]; then
                 HAS_LINT=$(jq -r '.scripts.lint // empty' package.json)
                 HAS_ESLINT=$(jq -r '.scripts.eslint // empty' package.json)
 
@@ -84,6 +92,8 @@ runs:
                 else
                   echo "::warning::No lint script found in package.json, skipping linting"
                 fi
+              else
+                echo "::warning::No package.json found, skipping linting"
               fi
               ;;
 

--- a/.github/actions/run-tests/action.yaml
+++ b/.github/actions/run-tests/action.yaml
@@ -173,7 +173,16 @@ runs:
           # Auto-detect and run appropriate tests
           case "$STACK" in
             nodejs)
-              if command -v jq &> /dev/null && [[ -f "package.json" ]]; then
+              # jq is required to read package.json scripts. If it is missing,
+              # the old `if command -v jq && ...` guard silently skipped the
+              # whole block, leaving TEST_EXIT_CODE unset so `exit ${VAR:-0}`
+              # reported a false pass. Fail hard instead — critical on
+              # self-hosted runner images that may not ship jq.
+              if ! command -v jq &> /dev/null; then
+                echo "::error::jq is required to detect Node.js test scripts but is not installed on this runner. Add jq to the runner image."
+                exit 1
+              fi
+              if [[ -f "package.json" ]]; then
                 HAS_TEST=$(jq -r '.scripts.test // empty' package.json)
                 HAS_TEST_CI=$(jq -r '.scripts["test:ci"] // empty' package.json)
 
@@ -192,6 +201,10 @@ runs:
                   TEST_COMMAND_USED="none"
                   TEST_EXIT_CODE=0
                 fi
+              else
+                echo "::warning::No package.json found, skipping tests"
+                TEST_COMMAND_USED="none"
+                TEST_EXIT_CODE=0
               fi
               ;;
 

--- a/.github/actions/security-scan/action.yaml
+++ b/.github/actions/security-scan/action.yaml
@@ -115,6 +115,28 @@ runs:
         set -euo pipefail
         echo "::warning::Dependency review skipped — GitHub Advanced Security is not available on this private repository (team plan needs Enterprise). See PRI-715."
 
+    - name: Check Dependency Review Results
+      # dependency_review runs with continue-on-error so the Security Summary
+      # always renders. That means a failing review never fails the action on
+      # its own — re-check the outcome here and fail explicitly when the caller
+      # opted into fail-on-vulnerabilities. Mirrors the TruffleHog gate above.
+      if: |
+        inputs.enable-dependency-review == 'true' &&
+        inputs.fail-on-vulnerabilities == 'true' &&
+        github.event_name == 'pull_request' &&
+        steps.dependency_review.outcome == 'failure'
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "::error::Dependency review found vulnerabilities at or above the configured severity threshold (fail-on-vulnerabilities is enabled)."
+        {
+          echo "### ⚠️ Security Alert: Vulnerable Dependencies"
+          echo ""
+          echo "The dependency review detected vulnerabilities at or above the configured severity threshold."
+          echo "Review the dependency-review findings on the PR and update or remove the affected packages."
+        } >> "$GITHUB_STEP_SUMMARY"
+        exit 1
+
     - name: Security Summary
       shell: bash
       env:

--- a/.github/actions/sync-branches/action.yaml
+++ b/.github/actions/sync-branches/action.yaml
@@ -95,7 +95,7 @@ runs:
         MERGE_BASE=$(git merge-base "origin/$SOURCE_BRANCH" "origin/$TARGET_BRANCH")
 
         # Get the latest commit on source branch
-        SOURCE_COMMIT=$(git rev-parse origin/$SOURCE_BRANCH)
+        SOURCE_COMMIT=$(git rev-parse "origin/$SOURCE_BRANCH")
 
         # Check if target is already up to date
         if [[ "$MERGE_BASE" == "$SOURCE_COMMIT" ]]; then
@@ -127,7 +127,7 @@ runs:
         # Merge source branch
         # Use --no-ff to create a merge commit (important for release-please to skip it)
         # Use special commit message format that release-please ignores
-        git merge origin/$SOURCE_BRANCH \
+        git merge "origin/$SOURCE_BRANCH" \
           --no-ff \
           --no-edit \
           -m "chore: sync $SOURCE_BRANCH to $TARGET_BRANCH [skip ci]" \
@@ -155,7 +155,7 @@ runs:
         fi
 
         # Push to target branch
-        git push origin $TARGET_BRANCH
+        git push origin "$TARGET_BRANCH"
 
         echo "✅ Successfully synced $SOURCE_BRANCH to $TARGET_BRANCH"
         echo "::endgroup::"

--- a/.github/config/schemas/pipeline-config.schema.json
+++ b/.github/config/schemas/pipeline-config.schema.json
@@ -47,6 +47,21 @@
         }
       }
     },
+    "runner": {
+      "type": "object",
+      "description": "Runner selection for the static-checks, verify and deploy-docker jobs. Only meaningful when a matching runner is registered against this repo (runners are repo-scoped).",
+      "additionalProperties": false,
+      "properties": {
+        "labels": {
+          "type": "array",
+          "description": "Labels passed to runs-on. Defaults to [\"ubuntu-latest\"] when omitted.",
+          "items": {
+            "type": "string"
+          },
+          "default": ["ubuntu-latest"]
+        }
+      }
+    },
     "security": {
       "type": "object",
       "description": "Security scanning configuration",

--- a/.github/workflows/nightly-maintenance.yaml
+++ b/.github/workflows/nightly-maintenance.yaml
@@ -145,7 +145,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          actionlint -color || true
           echo "### 🔍 Workflow Lint" >> "$GITHUB_STEP_SUMMARY"
           ERRORS=$(actionlint -format '{{range $err := .}}{{$err}}\n{{end}}' 2>&1 || true)
           if [[ -z "$ERRORS" ]]; then
@@ -156,6 +155,11 @@ jobs:
             echo "$ERRORS" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
           fi
+          # Surface the findings with color in the job log AND fail the job when
+          # actionlint reports issues. The previous `actionlint -color || true`
+          # swallowed the exit code, so workflow-lint errors never failed
+          # nightly maintenance.
+          actionlint -color
 
   maintenance-summary:
     name: 📊 Maintenance Summary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,37 +63,11 @@ jobs:
           manifest-file: .release-please-manifest.json
           target-branch: main
 
-      - name: 🤖 Enable auto-merge on release PR
-        if: steps.release.outputs.release_created != 'true'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-          PR_OUTPUT: ${{ steps.release.outputs.pr }}
-        run: |
-          set -euo pipefail
-          # Try release-please pr output first (JSON or plain number)
-          pr_number=""
-          if [[ -n "$PR_OUTPUT" ]]; then
-            if [[ "$PR_OUTPUT" =~ ^\{ ]]; then
-              pr_number=$(echo "$PR_OUTPUT" | jq -r '.number // empty')
-            elif [[ "$PR_OUTPUT" =~ ^[0-9]+$ ]]; then
-              pr_number="$PR_OUTPUT"
-            fi
-          fi
-
-          # Fallback: find open release PR by label
-          if [[ -z "$pr_number" ]]; then
-            pr_number=$(gh pr list --label "autorelease: pending" --json number --jq '.[0].number // empty' 2>/dev/null || true)
-          fi
-
-          if [[ -n "$pr_number" && "$pr_number" =~ ^[0-9]+$ ]]; then
-            echo "Enabling auto-merge for release PR #${pr_number}"
-            if ! gh pr merge "$pr_number" --squash --auto; then
-              echo "::warning::Could not enable auto-merge for release PR #${pr_number}; continuing without failing the workflow."
-            fi
-          else
-            echo "No open release PR found."
-          fi
+      # NOTE: This workflow cuts the STABLE (main) release. The stable
+      # release-please PR and the dev→main promotion are board-only — CI must
+      # never auto-enable merge on them (and squash is the wrong method for
+      # main, which uses merge commits). Auto-merge of the beta release PR lives
+      # in release-dev.yaml, where squash on dev is correct.
 
   update-major-tag:
     name: 🏷️ Update Major Version Tag

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -55,15 +55,31 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Check for App secrets
+        id: check-app
+        shell: bash
+        env:
+          APP_ID: ${{ secrets.WORKFLOW_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.WORKFLOW_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$APP_ID" && -n "$APP_PRIVATE_KEY" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate App token
         id: app-token
-        if: env.HAS_APP == 'true'
+        # A step's own `env:` is not visible to its `if:`, so the previous
+        # `if: env.HAS_APP == 'true'` was always false and the app token was
+        # never generated. Gate on a prior step output instead (secrets are not
+        # allowed directly in step `if:` expressions).
+        if: steps.check-app.outputs.available == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v2.1.4
         with:
           app-id: ${{ secrets.WORKFLOW_APP_ID }}
           private-key: ${{ secrets.WORKFLOW_APP_PRIVATE_KEY }}
-        env:
-          HAS_APP: ${{ secrets.WORKFLOW_APP_ID != '' && secrets.WORKFLOW_APP_PRIVATE_KEY != '' }}
 
       - name: Resolve token
         id: token

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -590,8 +590,17 @@ jobs:
             [[ -z "$file" ]] && continue
             case "$file" in
               *.md|*.mdx) ;;
-              docs/*|*/docs/*) ;;
               LICENSE|LICENSE.*|*/LICENSE|*/LICENSE.*) ;;
+              docs/*|*/docs/*)
+                # A file merely living under a docs/ directory is NOT enough to
+                # treat the change-set as docs-only: code such as docs/deploy.sh
+                # or src/docs/loader.ts must still run the full pipeline. Only
+                # count files under docs/ that carry a documentation extension.
+                case "$file" in
+                  *.md|*.mdx|*.txt|*.rst|*.adoc|*.png|*.jpg|*.jpeg|*.gif|*.svg|*.webp) ;;
+                  *) DOCS_ONLY=false; NON_DOC_FILE="$file"; break ;;
+                esac
+                ;;
               *) DOCS_ONLY=false; NON_DOC_FILE="$file"; break ;;
             esac
           done <<< "$CHANGED"


### PR DESCRIPTION
## NAV-22 — Land NAV-21 audit fixes to the universal pipeline

Independent logic-bug fixes surfaced by the NAV-21 audit. **No check is weakened.** The Check Gate skip-hole itself stays with NAV-20 and is out of scope here.

Each fix is a separate commit:

1. **HIGH — `security-scan`:** `fail-on-vulnerabilities:true` was a no-op — dependency-review is `continue-on-error` with no re-check. Added an explicit outcome re-check that exits 1 only when the caller opted in (mirrors the TruffleHog gate).
2. **HIGH — `release.yaml`:** removed the step that auto-enabled merge (`--squash --auto`) on the **stable/main** release-please PR. Stable release + dev→main promotion are board-only, and squash is the wrong method for `main`. Beta auto-merge is unchanged in `release-dev.yaml`.
3. **HIGH — `trunk-upgrade.yaml`:** a step's own `env:` is not visible to its `if:`, so `if: env.HAS_APP` was always false and the app token step never ran. Gated on a prior `check-app` step output instead.
4. **MED/HIGH — `deploy-coolify`:** a deploy that never reached `running` within the timeout emitted a warning and exited 0. Now emits an error and exits 1; the `always()` summary still renders.
5. **MED — `run-tests`/`run-lint`/`run-build`:** the nodejs branch was guarded by `command -v jq`; a missing `jq` silently skipped it and `exit ${TEST_EXIT_CODE:-0}` reported a false pass. Now fails hard when `jq` is absent (soft skip retained only for a genuinely absent `package.json`). Critical before self-hosted runner rollout.
6. **MED — docs-only glob (`universal-pipeline.yaml`):** `docs/*` / `*/docs/*` matched any file type, so `docs/deploy.sh` or `src/docs/loader.ts` skipped lint/test/build/security. Now scoped to documentation extensions.
7. **LOW — assorted:** `nightly-maintenance` drops `actionlint || true` so lint errors fail the job (summary still renders first); pipeline-config schema gains a `runner.labels` block with `additionalProperties:false` so typos like `runner.label` are caught; `sync-branches` quotes its branch refs.

### Verification
- `actionlint 1.7.7` clean on all edited workflows.
- JSON schema + YAML parse OK on every edited file.
- Unit-tested the docs-only classifier (code under `docs/` now triggers the full pipeline; md/txt/rst/images still skip) and the `jq`-missing hard-fail path.

Refs NAV-22. Parent NAV-21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
