### PR TITLE
fix(ci): a required gate can never pass on skipped validation (NAV-20)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,12 +259,21 @@ jobs:
           set -euo pipefail
           command -v jq >/dev/null || { echo "::error::jq not available"; exit 1; }
           echo "Job results: $RESULTS"
-          FAILURES=$(echo "$RESULTS" | jq -r 'map(select(. == "failure" or . == "cancelled")) | length')
-          if [[ "$FAILURES" -gt 0 ]]; then
-            echo "::error::Pipeline failed — ${FAILURES} job(s) failed or were cancelled"
+          # Root-cause fix (NAV-20): a required gate must NEVER pass on a
+          # skipped required job. The old logic counted only 'failure' and
+          # 'cancelled', so a required check reported as 'skipped' (e.g. Test
+          # not run on a synchronize push) slipped through as green. This gate
+          # aggregates the required validation jobs (lint, test, build), every
+          # one of which must run on every PR, so we assert each is exactly
+          # 'success' — anything else (skipped/failure/cancelled) fails the gate.
+          NOT_PASSED=$(echo "$RESULTS" | jq -r 'map(select(. != "success")) | length')
+          if [[ "$NOT_PASSED" -gt 0 ]]; then
+            BAD=$(echo "$RESULTS" | jq -rc 'map(select(. != "success"))')
+            echo "::error::Pipeline gate failed — ${NOT_PASSED} required job(s) did not succeed (non-success results: ${BAD})."
+            echo "::error::A required check reported as skipped/failure/cancelled cannot satisfy the gate."
             exit 1
           fi
-          echo "✅ All pipeline jobs passed"
+          echo "✅ All required pipeline jobs ran and passed"
 
   # ---------------------------------------------------------------------------
   # Auto-merge — enable auto-merge for dependabot PRs

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -1496,3 +1496,86 @@ jobs:
           prerelease-manifest-file: ${{ needs.setup.outputs.release-manifest-file }}
           stable-manifest-file: ${{ needs.setup.outputs.release-manifest-file-stable }}
           stable-version: ${{ needs.release.outputs.release-version }}
+
+  # =============================================================================
+  # PIPELINE GATE — hard invariant: a required check never passes on skipped tests
+  # =============================================================================
+  # Root-cause fix for the logical hole where `verify` (Test/Build) or
+  # `static-checks` (Lint/Security) were *skipped* for a non-legitimate reason
+  # yet the reusable workflow still reported success — GitHub treats an
+  # `if:`-skipped job as non-failing, so the caller's `Check Gate`
+  # (`case failure|cancelled) exit 1`) went green without validation ever running.
+  # The `gh pr ready --undo && ready` dance was a manual workaround for this.
+  #
+  # This job runs with `always()` and fails the whole reusable workflow (hence
+  # the caller's Check Gate) when, on a *validating* pull_request (ready, not
+  # docs-only), a stage that is ENABLED in pipeline.yaml did not actually run and
+  # succeed. Push events legitimately skip validation (the PR already proved it),
+  # so the strict must-run assertion is scoped to pull_request events only.
+  #
+  # Because every consumer calls this reusable workflow at a moving major tag
+  # (`@v3`), this fix propagates to the whole org with no per-repo change.
+  pipeline-gate:
+    name: 🚦 Pipeline Gate
+    if: always()
+    needs: [setup, static-checks, verify]
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions: {}
+    steps:
+      - name: Enforce validation invariants
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+          DOCS_ONLY: ${{ needs.setup.outputs.docs-only }}
+          ENABLE_TEST: ${{ needs.setup.outputs.enable-test }}
+          ENABLE_BUILD: ${{ needs.setup.outputs.enable-build }}
+          ENABLE_LINT: ${{ needs.setup.outputs.enable-lint }}
+          ENABLE_SECURITY: ${{ needs.setup.outputs.enable-security }}
+          SETUP_RESULT: ${{ needs.setup.result }}
+          STATIC_RESULT: ${{ needs.static-checks.result }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+        run: |
+          set -euo pipefail
+          echo "event=$EVENT_NAME draft=${IS_DRAFT:-n/a} docs_only=${DOCS_ONLY:-false}"
+          echo "results: setup=$SETUP_RESULT static-checks=$STATIC_RESULT verify=$VERIFY_RESULT"
+
+          # Setup is the source of truth for what should run; if it did not
+          # succeed the whole run is untrustworthy.
+          if [[ "$SETUP_RESULT" != "success" ]]; then
+            echo "::error::Setup did not succeed (result=$SETUP_RESULT); cannot certify pipeline."
+            exit 1
+          fi
+
+          # Any hard failure/cancellation in a validation stage fails the gate.
+          for pair in "static-checks:$STATIC_RESULT" "verify:$VERIFY_RESULT"; do
+            stage="${pair%%:*}"; res="${pair#*:}"
+            if [[ "$res" == "failure" || "$res" == "cancelled" ]]; then
+              echo "::error::Validation stage '$stage' $res."
+              exit 1
+            fi
+          done
+
+          # Strict must-run enforcement only on validating pull_request events.
+          # Draft PRs cannot be merged; docs-only changes legitimately skip.
+          if [[ "$EVENT_NAME" != "pull_request" || "$IS_DRAFT" == "true" || "$DOCS_ONLY" == "true" ]]; then
+            echo "✅ Non-validating context — gate satisfied."
+            exit 0
+          fi
+
+          fail=0
+          if [[ "$ENABLE_TEST" == "true" || "$ENABLE_BUILD" == "true" ]]; then
+            if [[ "$VERIFY_RESULT" != "success" ]]; then
+              echo "::error::Test/Build are enabled but the Verify stage did not run (result=$VERIFY_RESULT). A required gate must not pass on skipped tests."
+              fail=1
+            fi
+          fi
+          if [[ "$ENABLE_LINT" == "true" || "$ENABLE_SECURITY" == "true" ]]; then
+            if [[ "$STATIC_RESULT" != "success" ]]; then
+              echo "::error::Lint/Security are enabled but Static Checks did not run (result=$STATIC_RESULT)."
+              fail=1
+            fi
+          fi
+          [[ "$fail" -eq 0 ]] || exit 1
+          echo "✅ All enabled validation stages ran and passed."


### PR DESCRIPTION
## Summary

Root-cause fix for the documented **Check Gate skip-hole**: a required status check could report green while a required validation job was `skipped` (e.g. Test/Build not run on a `synchronize` push). This is the bug our AGENTS policy works around with the `gh pr ready --undo && ready` dance — this PR removes the need for that.

## Changes (two layers of defense)

1. **`ci.yaml` — Check Gate aggregator** (the job wired into the org ruleset's required check for this repo). The old jq counted only `failure`/`cancelled`, so a `skipped` required job slipped through. Now every required job (`lint`, `test`, `build`) must be exactly `success`; `skipped`/`failure`/`cancelled` all fail the gate.

2. **`universal-pipeline.yaml` — new `🚦 Pipeline Gate` job.** An `always()` job that fails the reusable workflow (and therefore the caller's required check) when, on a *validating* `pull_request`, a stage **enabled** in `pipeline.yaml` did not actually run and succeed. Scoped to `pull_request` (draft/docs-only/push are legitimately exempt). Because consumers pin `@v3`, this propagates org-wide with **no per-repo change**.

## Why both

`ci.yaml` fixes this repo's own gate; the reusable `Pipeline Gate` closes the same class of hole for every consuming repo without waiting on the org-wide rollout.

## Verification

- `actionlint` (v1.7.7, `-shellcheck=""`, same as CI) passes clean on both files.
- YAML parses; `pipeline-gate` `needs`/outputs (`setup`, `static-checks`, `verify`; `enable-test/build/lint/security`, `docs-only`) verified to exist.

## Review

I authored this — **routing to Reviewer/QA, not self-approving.** Feature PR into `dev` per GitHub Change Flow.

Refs NAV-20 (parent NAV-19).