### PR TITLE
docs(runner): hardened self-hosted runner + library/WP pipeline templates (NAV-27)

### DIFF
--- a/.github/config/examples/library-npm-pipeline.yaml
+++ b/.github/config/examples/library-npm-pipeline.yaml
@@ -1,0 +1,56 @@
+---
+# Pipeline configuration for a publishable npm LIBRARY (no deployment).
+# Use for packages like eslint-config and generated type packages
+# (e.g. directus-types). Save this as .github/pipeline.yaml in your project.
+#
+# A library differs from an app: it is lint + test + build + release, with
+# `deployment.provider: none`. Releases are cut by release-please (beta on dev,
+# stable on main) exactly like every other navigaite repo.
+version: '2.0'
+
+stack: nodejs
+runtime:
+  node_version: '24'
+
+pipeline:
+  fail_fast: false
+  enable_caching: true
+
+security:
+  enable: true
+  trufflehog: true
+  dependency_review: true
+  fail_on_secrets: true
+  fail_on_vulnerabilities: false
+
+lint:
+  enable: true
+  # Uses `npm run lint` from package.json by default.
+
+test:
+  enable: true
+  coverage: true
+  # A types-only package with no runtime tests may set `enable: false`,
+  # but prefer keeping a smoke test (e.g. `tsc --noEmit`) via a custom command:
+  # command: npm run typecheck
+
+build:
+  enable: true
+  # Uses `npm run build` (e.g. tsc / tsup) from package.json.
+  upload_artifacts: false
+
+deployment:
+  provider: none
+
+release:
+  enable: true
+  type: node
+  strategy: release-please
+  config_file: .github/release-please-config.json        # prerelease on dev
+  config_file_stable: .github/release-please-config.main.json  # stable on main
+  manifest_file: .release-please-manifest.json
+  sync_to_dev: true
+  sync_target_branch: dev
+  prerelease_branches:
+    - branch: dev
+      label: beta

--- a/.github/config/examples/wordpress-theme-pipeline.yaml
+++ b/.github/config/examples/wordpress-theme-pipeline.yaml
@@ -1,0 +1,56 @@
+---
+# Pipeline configuration for a WordPress theme (e.g. fesu-wp-theme).
+# Save this as .github/pipeline.yaml in your project.
+#
+# CAVEAT: the universal pipeline's `stack` detection supports
+# auto | nodejs | python | flutter — there is NO native PHP/WordPress stack.
+# So a WP theme runs with `stack: auto` and EXPLICIT commands for any lint/test,
+# or with those stages disabled. Native PHP support (phpcs/phpunit/composer) is
+# tracked as a pipeline enhancement follow-up; until then this template gives a
+# safe minimum: secret scanning + release management always on, code checks
+# wired only where the theme actually provides them.
+version: '2.0'
+
+stack: auto
+
+pipeline:
+  fail_fast: false
+  enable_caching: true
+
+security:
+  enable: true          # TruffleHog secret scan works for any stack
+  trufflehog: true
+  dependency_review: true
+  fail_on_secrets: true
+  fail_on_vulnerabilities: false
+
+lint:
+  # Enable only if the theme ships a linter. WordPress Coding Standards:
+  #   command: vendor/bin/phpcs --standard=WordPress .
+  # If the theme has an npm toolchain (assets), `npm run lint` also works.
+  enable: false
+
+test:
+  # Enable only if the theme ships tests (e.g. PHPUnit):
+  #   command: vendor/bin/phpunit
+  enable: false
+
+build:
+  # Theme asset build, if any (e.g. `npm run build` for block/editor assets).
+  enable: false
+
+deployment:
+  provider: none        # theme is shipped as a release artifact, not deployed by CI
+
+release:
+  enable: true
+  type: simple          # not a node/python package — version the theme itself
+  strategy: release-please
+  config_file: .github/release-please-config.json
+  config_file_stable: .github/release-please-config.main.json
+  manifest_file: .release-please-manifest.json
+  sync_to_dev: true
+  sync_target_branch: dev
+  prerelease_branches:
+    - branch: dev
+      label: beta

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 | [Versioning Guide](./VERSIONING_GUIDE.md) | Semantic versioning + conventional commits |
 | [Auto Sync Feature](./AUTO_SYNC_FEATURE.md) | Post-release main → dev sync |
 | [GitHub Settings Guide](./GITHUB_SETTINGS_GUIDE.md) | Repo & org configuration |
+| [Self-Hosted Runner](./SELF_HOSTED_RUNNER.md) | Hardened homelab runner — protects the Actions budget |
 | [Actions Marketplace](./GITHUB_ACTIONS_MARKETPLACE.md) | Curated actions used in the pipeline |
 
 ## Examples
@@ -20,3 +21,5 @@ See [`.github/config/examples/`](../.github/config/examples/) for ready-to-use c
 - [Python + DigitalOcean](../.github/config/examples/python-digitalocean-pipeline.yaml)
 - [Flutter](../.github/config/examples/flutter-pipeline.yaml)
 - [Docker Only](../.github/config/examples/docker-only-pipeline.yaml)
+- [npm Library](../.github/config/examples/library-npm-pipeline.yaml)
+- [WordPress Theme](../.github/config/examples/wordpress-theme-pipeline.yaml)

--- a/docs/SELF_HOSTED_RUNNER.md
+++ b/docs/SELF_HOSTED_RUNNER.md
@@ -1,0 +1,88 @@
+# Self-Hosted Runner (homelab)
+
+Navigaite runs a self-hosted GitHub Actions runner on the Mainz homelab (Unraid)
+so that the org's **private-repo** CI does not consume the board-set **$20/month**
+GitHub Actions spending cap. This guide is the hardened, safe way to operate it.
+
+> **Public repos never use this runner.** `navigaite/.github` and
+> `navigaite/nvgt-trunk-plugin` are public; fork PRs can run arbitrary code.
+> Untrusted code must not execute on the homelab. Public repos stay on
+> GitHub-hosted `ubuntu-latest` (which is free for public repos anyway).
+
+A ready-to-deploy Compose stack lives next to this file:
+[`self-hosted-runner/docker-compose.yml`](./self-hosted-runner/docker-compose.yml).
+
+## Why hardening was required
+
+The legacy `gh-actions-runner` stack ran `myoung34/github-runner:latest` with:
+
+| Legacy setting | Risk | Fix |
+| --- | --- | --- |
+| `privileged: true` + in-container Docker-in-Docker | Container escape → host root on the homelab | Drop `privileged`; disable in-container Docker; use rootless BuildKit only where image builds are needed |
+| `image: ...:latest` | Unpinned — a compromised/moved tag silently changes what runs | Pin by digest (`@sha256:…`) |
+| Repo-scoped, one container per repo | Doesn't scale to the fleet; each needs its own PAT | One **org-level runner group** (`homelab`) for all private repos |
+| `docker` label advertised | Misleads jobs into scheduling Docker work on a daemonless runner | Fleet labels: `self-hosted, mainz-homelab, linux, x64` |
+
+`jq` is baked into the myoung34 image and is intentionally kept — the pipeline's
+Node lint/test/build steps depend on it (a missing `jq` silently no-ops those
+steps to a false success; see the NAV-22 audit).
+
+## Topology
+
+Two ways to register, selected by Docker Compose profile in the stack file:
+
+- **Option A — org runner group (preferred).** One runner group named `homelab`
+  at the org level, access **limited to private repos**, serving every private
+  navigaite repo. Requires an `ACCESS_TOKEN` (PAT) with **`admin:org`**.
+  → `docker compose --profile org up -d`
+- **Option B — repo-scoped (interim).** One container per opted-in private repo,
+  registered with a `repo`-scope PAT. Mirrors the legacy topology, hardened.
+  Use only until `admin:org` is available. → `docker compose --profile repo up -d`
+
+### Prerequisite: `admin:org` for Option A
+
+Creating an org runner group and reading Actions billing needs `admin:org`, which
+the CTO `gh` token does **not** currently carry (`gist, read:org, repo, workflow`).
+Grant it interactively:
+
+```bash
+gh auth refresh -s admin:org
+```
+
+or provision a scoped PAT (`admin:org`) in the runner's secret store as
+`RUNNER_ORG_TOKEN`. This is a board/human step (interactive OAuth).
+
+## Wiring a repo to the runner
+
+Runners are matched by label. In a repo's `.github/pipeline.yaml`:
+
+```yaml
+runner:
+  labels: [self-hosted, mainz-homelab, linux, x64]
+```
+
+This routes the `static-checks`, `verify` and `deploy-docker` jobs to the
+homelab runner; it defaults to `ubuntu-latest` when omitted.
+
+> **Gotcha — do not set self-hosted labels on a repo with no matching runner.**
+> Jobs pinned to `self-hosted` labels queue **forever** if no runner is
+> registered/authorized for that repo. Only add `runner.labels` after the repo
+> is served by the org group (or has its own repo-scoped runner). Public repos
+> keep the default (`ubuntu-latest`).
+
+## Repos that build container images
+
+Most of the fleet (Node/Vercel apps, npm libraries, the WP theme) build **no**
+container image in CI, so the default runner runs with Docker disabled. Only a
+repo whose `pipeline.yaml` sets `deployment.provider: docker` (the `deploy-docker`
+job) needs to build images. Give those a **rootless BuildKit** sidecar
+(`--profile docker` in the stack) and point the build at it — never re-enable
+privileged dind.
+
+## Operating notes
+
+- Runners are `EPHEMERAL` — a fresh runner per job, no state carried across jobs.
+- Recreate containers only when idle; an ephemeral runner mid-job will finish and
+  deregister on its own.
+- Keep the digest current deliberately (Dependabot/renovate on this file or a
+  scheduled bump), not via `:latest`.

--- a/docs/self-hosted-runner/docker-compose.yml
+++ b/docs/self-hosted-runner/docker-compose.yml
@@ -1,0 +1,103 @@
+---
+# Navigaite hardened self-hosted GitHub Actions runner (homelab / Unraid).
+#
+# This replaces the legacy `gh-actions-runner` stack that ran
+# `myoung34/github-runner:latest` with `privileged: true` and in-container
+# Docker-in-Docker. See docs/SELF_HOSTED_RUNNER.md for the full rationale.
+#
+# Hardening applied vs. the legacy stack:
+#   1. Image pinned by digest (no `:latest` — supply-chain integrity).
+#   2. `privileged: true` REMOVED. `no-new-privileges` + `cap_drop: ALL`.
+#   3. In-container Docker DISABLED by default (DOCKER_ENABLED/START_DOCKER
+#      _SERVICE=false). The Navigaite fleet is Node/Vercel, libraries and a WP
+#      theme — none of which build container images in CI. Repos that DO need
+#      image builds use rootless BuildKit (see the `runner-docker` profile
+#      below and the guide), never privileged dind.
+#   4. The `docker` label is dropped from the default runner (it no longer has
+#      a Docker daemon). pipeline.yaml `runner.labels` for the fleet is:
+#        [self-hosted, mainz-homelab, linux, x64]
+#
+# PUBLIC repos (navigaite/.github, navigaite/nvgt-trunk-plugin) are NEVER
+# assigned to this runner: untrusted fork-PR code must not execute on the
+# homelab. Keep them on GitHub-hosted `ubuntu-latest`.
+#
+# ACCESS_TOKEN is injected from the host environment / secret store, never
+# committed. For the org-level runner group variant it must carry `admin:org`.
+
+x-runner-base: &runner-base
+  image: myoung34/github-runner@sha256:6c4650a57d7727419ebb11ca1d7f054e971b9f0769c27118b185302cbf09c282
+  restart: unless-stopped
+  security_opt:
+    - no-new-privileges:true
+  cap_drop:
+    - ALL
+  environment: &runner-env
+    EPHEMERAL: "true"          # fresh runner per job — no state carried between jobs
+    DISABLE_AUTO_UPDATE: "true"
+    START_DOCKER_SERVICE: "false"
+    DOCKER_ENABLED: "false"
+    RUNNER_WORKDIR: /_work
+  # jq is baked into the myoung34 image; the pipeline's Node lint/test/build
+  # steps depend on it (a missing jq silently no-ops to success — NAV-22).
+  tmpfs:
+    - /tmp
+  volumes:
+    - /_work
+
+services:
+  # ---------------------------------------------------------------------------
+  # Option A (preferred once the CTO token has `admin:org`): ONE org-level
+  # runner group serving all PRIVATE navigaite repos. Replaces the per-repo
+  # containers. Requires an ACCESS_TOKEN with `admin:org` and a runner group
+  # (`homelab`) created at the org level with access limited to private repos.
+  # ---------------------------------------------------------------------------
+  runner-org:
+    <<: *runner-base
+    container_name: gh-runner-navigaite-homelab
+    profiles: ["org"]
+    environment:
+      <<: *runner-env
+      RUNNER_SCOPE: org
+      ORG_NAME: navigaite
+      RUNNER_GROUP: homelab
+      RUNNER_NAME: mainz-homelab-navigaite
+      LABELS: self-hosted,mainz-homelab,linux,x64
+      ACCESS_TOKEN: ${RUNNER_ORG_TOKEN}   # PAT with admin:org
+
+  # ---------------------------------------------------------------------------
+  # Option B (interim, no admin:org): repo-scoped runner. Duplicate this
+  # service per private repo that opts in. This mirrors the legacy topology
+  # but hardened. Prefer Option A.
+  # ---------------------------------------------------------------------------
+  runner-repo-example:
+    <<: *runner-base
+    container_name: gh-runner-example
+    profiles: ["repo"]
+    environment:
+      <<: *runner-env
+      RUNNER_SCOPE: repo
+      REPO_URL: https://github.com/navigaite/REPLACE_ME
+      RUNNER_NAME: mainz-homelab-REPLACE_ME
+      LABELS: self-hosted,mainz-homelab,linux,x64
+      ACCESS_TOKEN: ${RUNNER_REPO_TOKEN}  # PAT with repo scope
+
+  # ---------------------------------------------------------------------------
+  # Docker-capable variant — ONLY for repos whose pipeline.yaml deploys a
+  # container image (deployment.provider: docker → deploy-docker job). Uses a
+  # ROOTLESS BuildKit sidecar instead of privileged dind. Point the deploy job
+  # at the buildkit builder; the runner itself stays unprivileged.
+  # ---------------------------------------------------------------------------
+  buildkit-rootless:
+    image: moby/buildkit:rootless
+    container_name: gh-runner-buildkit
+    profiles: ["docker"]
+    restart: unless-stopped
+    security_opt:
+      - seccomp=unconfined       # required by rootless buildkitd (userns)
+      - apparmor=unconfined
+    # NOTE: rootless BuildKit still needs userns; it does NOT need full
+    # `privileged`. See https://github.com/moby/buildkit/blob/master/docs/rootless.md
+    command:
+      - --addr
+      - tcp://0.0.0.0:1234
+      - --oci-worker-no-process-sandbox


### PR DESCRIPTION
## What
Enablement artifacts for the NAV-21 org-wide pipeline rollout (**NAV-27**, scope 2 + 3). Docs/templates only — no workflow logic changes.

### Scope 2 — self-hosted runner (durable \$20 Actions-budget fix)
- **`docs/SELF_HOSTED_RUNNER.md`** — hardened rootless runner design:
  - drop `privileged: true` + in-container dind (host-escape blocker),
  - **pin the image by digest** (`myoung34/github-runner@sha256:6c46…`) instead of `:latest` (supply-chain),
  - keep `jq` (a missing `jq` silently no-ops Node lint/test/build — NAV-22),
  - **Docker disabled by default** (the fleet builds no container images) + a **rootless BuildKit** variant for the few repos that do,
  - **exclude the 2 public repos** (`.github`, `nvgt-trunk-plugin`) — never run untrusted fork-PR code on the homelab,
  - org runner group vs. repo-scoped, and the **`runner.labels` gotcha** (self-hosted labels on a repo with no matching runner ⇒ jobs queue forever).
- **`docs/self-hosted-runner/docker-compose.yml`** — digest-pinned, non-privileged reference stack (`org` / `repo` / `docker` profiles).

### Scope 3 — rollout kit for non-app repos
- **`.github/config/examples/library-npm-pipeline.yaml`** — npm library (eslint-config, directus-types): lint/test/build/release, `deployment.provider: none`.
- **`.github/config/examples/wordpress-theme-pipeline.yaml`** — WP theme (fesu-wp-theme). ⚠️ The pipeline `stack` enum is `auto|nodejs|python|flutter` — **no native PHP/WP stack**; template uses `stack: auto` + secret-scan + release, code checks opt-in. Native PHP support is a follow-up.

Both configs are **schema-validated** against `pipeline-config.schema.json`.

## Blocked downstream (board)
The org-level runner group + Actions billing visibility need **`admin:org`** on the CTO token (currently `gist, read:org, repo, workflow`). Per the runner-first directive, the 12-repo private-repo migration is held until the runner is live to protect the \$20 cap.

Refs NAV-27 (parent NAV-21).