### PR TITLE
fix(runner): drop cap_drop ALL from hardened self-hosted runner compose

### DIFF
--- a/docs/self-hosted-runner/docker-compose.yml
+++ b/docs/self-hosted-runner/docker-compose.yml
@@ -7,7 +7,16 @@
 #
 # Hardening applied vs. the legacy stack:
 #   1. Image pinned by digest (no `:latest` — supply-chain integrity).
-#   2. `privileged: true` REMOVED. `no-new-privileges` + `cap_drop: ALL`.
+#   2. `privileged: true` REMOVED. `no-new-privileges:true` applied.
+#      NOTE: `cap_drop: ALL` is deliberately NOT used. The myoung34 entrypoint
+#      starts as root and drops to the `runner` user, and the runner writes its
+#      own `/actions-runner/_diag` + `.env`. Dropping ALL caps strips
+#      CAP_SETUID/CAP_SETGID (privilege-drop fails) and CAP_DAC_OVERRIDE/
+#      CAP_FOWNER (root can no longer write runner-owned paths), so the runner
+#      aborts on start. Verified against this digest on 2026-07-24 (NAV-27).
+#      `no-new-privileges` already blocks setuid escalation, which is the key
+#      win now that `privileged`/dind are gone. Per-capability tightening is a
+#      tested follow-up, not a drop-in.
 #   3. In-container Docker DISABLED by default (DOCKER_ENABLED/START_DOCKER
 #      _SERVICE=false). The Navigaite fleet is Node/Vercel, libraries and a WP
 #      theme — none of which build container images in CI. Repos that DO need
@@ -29,8 +38,8 @@ x-runner-base: &runner-base
   restart: unless-stopped
   security_opt:
     - no-new-privileges:true
-  cap_drop:
-    - ALL
+  # No `cap_drop: ALL` — see the header note (#2). This image's root→runner
+  # privilege drop and runner-owned writes need SETUID/SETGID/DAC_OVERRIDE.
   environment: &runner-env
     EPHEMERAL: "true"          # fresh runner per job — no state carried between jobs
     DISABLE_AUTO_UPDATE: "true"


### PR DESCRIPTION
## What
Live-testing the hardened self-hosted org runner on the homelab (NAV-27 scope 2) surfaced a startup bug in the compose that already landed on \`dev\`: \`cap_drop: ALL\` makes the myoung34 runner abort.

## Why
Under \`cap_drop: ALL\` the container root loses:
- \`CAP_SETUID\`/\`CAP_SETGID\` → the entrypoint's root→\`runner\` privilege drop fails, and
- \`CAP_DAC_OVERRIDE\`/\`CAP_FOWNER\` → root can no longer write the runner-owned \`/actions-runner/_diag\` and \`.env\`.

Result: `System.UnauthorizedAccessException: Access to the path '/actions-runner/_diag' is denied` and the runner never registers.

## Fix
Remove \`cap_drop: ALL\`; keep \`no-new-privileges:true\` (still blocks setuid escalation). The board's core ask — dropping \`privileged\` and in-container DinD — remains fully in place. Header comment documents the finding and flags per-capability tightening as a *tested* follow-up.

## Verification
With this config the org runner registers **online & idle** in the org \`homelab\` runner group (14 private repos; the 2 public repos are excluded). Verified via \`gh api orgs/navigaite/actions/runners\`.

Part of NAV-27 (NAV-21 scope 2 — self-hosted runner enablement).