### PR TITLE
fix(ci): drop checks:write over-request that startup-fails every consumer on @v3

### DIFF
--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -125,7 +125,10 @@ on:
 # NOTE: Calling workflows must grant the permissions each job actually uses:
 #   setup:     contents: read, pull-requests: read (PR Files API for docs-only detection)
 #   security:      contents: read, pull-requests: write
-#   static-checks: contents: read, pull-requests: write, checks: write (trunk-action check annotations)
+#   static-checks: contents: read, pull-requests: write
+#     (optional: add `checks: write` in the caller to let trunk-action post
+#      check annotations — never request it in this reusable workflow, it would
+#      exceed the caller's grant and fail every run at startup)
 #   build:     contents: read, id-token: write, attestations: write
 #   deploy:    contents: read, deployments: write, pull-requests: write, packages: write, id-token: write
 #   release:   contents: write, pull-requests: write, id-token: write
@@ -691,7 +694,14 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      checks: write # trunk-action posts lint results as check annotations (Checks API); without this it logs "Failed to post annotations to github: 403"
+      # NOTE: do NOT request `checks: write` here. A reusable workflow job may
+      # only request permissions the CALLER already grants; every consumer
+      # caller sets an explicit `permissions:` block that omits `checks`, so
+      # requesting `checks: write` makes GitHub reject the whole run at load
+      # time (startup_failure) for every repo. trunk-action degrades gracefully
+      # without it — it just logs "Failed to post annotations to github: 403"
+      # and lint still runs and gates correctly. A repo that wants the check
+      # annotations opts in by adding `checks: write` to its own caller.
     needs: setup
     if: |
       (needs.setup.outputs.enable-security == 'true' || needs.setup.outputs.enable-lint == 'true') &&


### PR DESCRIPTION
## P1 — org-wide CI outage

Since the `v3` tag moved to **v3.2.2** (the dev→main promotion, ~15:33Z 2026-07-24), **every** navigaite repo's pipeline fails at load with `startup_failure` ("This run likely failed because of a workflow file issue").

### Proof (same commit, before/after the tag move)
| Repo | attempt 1 (old v3) | attempt 2 (v3.2.2) |
|---|---|---|
| maimaldrei-website | ✅ success | ❌ startup_failure |
| nvgt-trunk-plugin (public) | ✅ success | ❌ startup_failure |
| maimaldrei-mietkatalog (fresh PR #799) | — | ❌ startup_failure ×2 |

### Root cause
#236 added `checks: write` to the **static-checks** job's `permissions:`. A **reusable-workflow job may only request permissions the caller already grants.** Every consumer caller (`ci.yaml`) sets an explicit `permissions:` block that omits `checks`, so GitHub rejects the entire run at load time. It was invisible in this repo's own CI because `.github/workflows/ci.yaml` runs bespoke jobs and does **not** call the reusable workflow. `checks: write` was the **only** over-requested scope (audited all 9 jobs).

### Fix
Remove the scope. trunk-action degrades gracefully (logs a `403` when posting annotations; **lint still runs and gates correctly**). Repos wanting annotations opt in by granting `checks: write` in their own caller. actionlint clean.

### Landing / promotion
This restores @v3 **only after the board promotes dev→main and moves the v3 tag.** For immediate relief the board can instead re-point `v3` → `v3.2.1` as a stopgap (loses #237/#236 temporarily), then promote this fix. See NAV-27.

Refs NAV-27.