### PR TITLE
feat(pipeline): add fast|major repo profile knob (NAV-21)

### DIFF
--- a/.github/config/examples/fast-library-pipeline.yaml
+++ b/.github/config/examples/fast-library-pipeline.yaml
@@ -1,0 +1,63 @@
+---
+# Pipeline configuration for a FAST-profile repo (single-branch, main only).
+# Use for small, internal, non-customer projects — shared libs, templates,
+# and tooling (e.g. nvgt-trunk-plugin, nvgt-repo-template, eslint-config).
+# Save this as .github/pipeline.yaml in your project.
+#
+# Fast vs Major:
+#   - Fast  = feature -> main (squash). release-please cuts STABLE releases
+#             directly on main. No dev branch, no beta channel, no promotion.
+#             CTO self-merges feature PRs (0 approvals). Branch Guard permits
+#             feature -> main because there is no dev branch.
+#   - Major = feature -> dev -> main. Beta on dev, board-only promotion cuts
+#             stable. See library-npm-pipeline.yaml / nextjs-vercel-pipeline.yaml.
+#
+# `profile: fast` forces the main->dev back-merge OFF, so this repo never fails
+# the sync step for a missing dev branch — no need to remember sync_to_dev.
+version: '2.0'
+
+profile: fast
+
+stack: nodejs
+runtime:
+  node_version: '24'
+
+pipeline:
+  fail_fast: false
+  enable_caching: true
+
+security:
+  enable: true
+  trufflehog: true
+  dependency_review: true
+  fail_on_secrets: true
+  fail_on_vulnerabilities: false
+
+lint:
+  enable: true
+  # Uses `npm run lint` from package.json by default.
+
+test:
+  enable: true
+  coverage: true
+
+build:
+  enable: true
+  # Uses `npm run build` from package.json.
+  upload_artifacts: false
+
+deployment:
+  provider: none
+
+release:
+  enable: true
+  type: node
+  strategy: release-please
+  # Single stable release stream on main — no prerelease_branches, no
+  # config_file_stable. release-please still generates versioning + release
+  # notes + a GitHub Release, exactly like Major repos, just on main only.
+  config_file: .github/release-please-config.json
+  manifest_file: .release-please-manifest.json
+  # No dev branch to sync back to. Redundant on the fast profile (the pipeline
+  # forces this off) but kept explicit for readers.
+  sync_to_dev: false

--- a/.github/config/schemas/pipeline-config.schema.json
+++ b/.github/config/schemas/pipeline-config.schema.json
@@ -12,6 +12,12 @@
       "pattern": "^2\\.\\d+$",
       "default": "2.0"
     },
+    "profile": {
+      "type": "string",
+      "description": "Repo delivery profile. 'major' = two-branch (feature -> dev -> main): beta prereleases on dev, board-only dev->main promotion cuts stable. 'fast' = single-branch (feature -> main squash): release-please cuts stable directly on main, no dev branch, no back-merge. On the 'fast' profile the pipeline forces the main->dev back-merge off, so a repo with no dev branch never fails the sync step.",
+      "enum": ["major", "fast"],
+      "default": "major"
+    },
     "stack": {
       "type": "string",
       "description": "Technology stack (auto-detected if not specified)",

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -158,6 +158,9 @@ jobs:
       # Change classification
       docs-only: ${{ steps.docs-check.outputs.docs-only }}
 
+      # Delivery profile: 'major' (two-branch) or 'fast' (single-branch main)
+      profile: ${{ steps.parse-config.outputs.profile }}
+
       # Tech stack detection
       stack: ${{ steps.setup-env.outputs.detected-stack }}
       runtime-version: ${{ steps.setup-env.outputs.runtime-version }}
@@ -280,6 +283,7 @@ jobs:
             ENABLE_RELEASE="false"
             ENABLE_SYNC="true"
             SYNC_TARGET="dev"
+            PROFILE="major"
             RELEASE_STRATEGY="release-please"
             RELEASE_TYPE=""
             RELEASE_FORCE_PATCH_NO_RELEASE="false"
@@ -318,6 +322,11 @@ jobs:
             }
 
             # Parse configuration using yq
+            PROFILE=$(yq -r '.profile // "major"' "$CONFIG_FILE")
+            if [[ "$PROFILE" != "major" && "$PROFILE" != "fast" ]]; then
+              echo "::error::Invalid profile '$PROFILE' in $CONFIG_FILE — must be 'major' or 'fast'."
+              exit 1
+            fi
             CONFIGURED_STACK=$(yq -r '.stack // "auto"' "$CONFIG_FILE")
             ENABLE_CACHING=$(yq_bool '.pipeline.enable_caching' true)
             # Self-hosted opt-in. Labels are only meaningful if a runner is
@@ -434,6 +443,15 @@ jobs:
           [[ "$SKIP_BUILD" == "true" ]] && ENABLE_BUILD="false"
           [[ "$SKIP_DEPLOY" == "true" ]] && ENABLE_DEPLOY="false"
 
+          # Fast profile: single-branch (main only), no dev branch. Force the
+          # main->dev back-merge off so the sync-to-dev job never tries to push
+          # to a dev branch that does not exist (which would hard-fail every
+          # stable release). This is enforced by profile, not left to the
+          # per-repo sync_to_dev flag, so a Fast repo cannot misconfigure it.
+          if [[ "$PROFILE" == "fast" ]]; then
+            ENABLE_SYNC="false"
+          fi
+
           # Resolve the branch-appropriate release-please manifest. On a
           # non-prerelease branch (e.g. main) use the stable manifest when one
           # is configured; otherwise the default manifest. Keeps the beta (dev)
@@ -453,6 +471,7 @@ jobs:
           fi
 
           # Output configuration
+          echo "profile=$PROFILE" >> $GITHUB_OUTPUT
           echo "configured-stack=$CONFIGURED_STACK" >> $GITHUB_OUTPUT
           echo "enable-caching=$ENABLE_CACHING" >> $GITHUB_OUTPUT
           echo "runner-labels=$RUNNER_LABELS" >> $GITHUB_OUTPUT
@@ -514,6 +533,7 @@ jobs:
 
           echo ""
           echo "📦 Configuration Summary:"
+          echo "  Profile: $PROFILE"
           echo "  Stack: $CONFIGURED_STACK"
           echo "  Caching: $ENABLE_CACHING"
           echo "  Security: $ENABLE_SECURITY"

--- a/docs/BRANCHING_STRATEGY.md
+++ b/docs/BRANCHING_STRATEGY.md
@@ -2,7 +2,34 @@
 
 This document explains how the Universal Pipeline v2 works with your Git branching strategy and automates deployments.
 
-## 📋 Recommended Branching Strategy
+## 🧭 Repo Profiles: Major vs Fast
+
+Every navigaite repo declares a delivery **profile** in `.github/pipeline.yaml`
+via the top-level `profile:` key (default `major`). Both profiles get
+release-please versioning + release notes + GitHub Releases — they differ only
+in branching and who ships production.
+
+| | **Major** (`profile: major`) | **Fast** (`profile: fast`) |
+| --- | --- | --- |
+| Use for | Customer / production repos | Small, internal, non-customer (libs, templates, tooling) |
+| Branches | `feature/*` → `dev` → `main` | `feature/*` → `main` |
+| Feature merge | squash into `dev` | squash into `main` |
+| Release channel | **beta** on `dev`, **stable** on `main` | **stable** on `main` only |
+| `dev` → `main` promotion | **board only** (merge commit) | n/a (no `dev` branch) |
+| Feature PR merge | CTO self-merge into `dev` | CTO self-merge into `main` (0 approvals) |
+| Back-merge (`sync_to_dev`) | on (main → dev after release) | off (forced off by profile) |
+
+**Always enforced on both profiles:** PR required into a protected branch,
+signed commits, `Check Gate` + full pipeline green, squash-only feature merges.
+
+**How Fast works with no `dev` branch:** the caller's `Branch Guard` allows a
+PR into `main` when the repo has no `dev` branch, and the reusable pipeline
+forces the main → dev back-merge off when `profile: fast`, so a stable release
+never fails trying to push to a branch that doesn't exist. See
+[`fast-library-pipeline.yaml`](../.github/config/examples/fast-library-pipeline.yaml)
+for a complete Fast config; the sections below describe the **Major** flow.
+
+## 📋 Recommended Branching Strategy (Major profile)
 
 The pipeline is optimized for a **main/dev branching strategy** with optional feature branches:
 


### PR DESCRIPTION
## What

Formalizes the board-approved **two-tier repo model** (NAV-19 → NAV-21) as an explicit `profile` knob.

- **schema** — new top-level `profile` enum (`major` | `fast`, default `major`).
- **universal-pipeline** — `setup` parses/validates `profile`, exposes it as a job output, and on `profile: fast` forces `enable-sync` (main→dev back-merge) **off**.
- **example** — `config/examples/fast-library-pipeline.yaml`: complete Fast config (stable-only release-please on `main`, no dev/beta channel, sync off).
- **docs** — Major vs Fast section in `BRANCHING_STRATEGY.md`.

## Why this is minimal

Fast release mechanics need no other pipeline change:
- release-please is already **branch-data-driven** — on a push to `main` with no matching `prerelease_branches`, it cuts a **stable** release. No dev branch needed.
- the caller **Branch Guard** already allows `feature → main` when the repo has **no `dev` branch** (the Fast shape).

The only real runtime behavior tied to the knob: a Fast repo must never try to back-merge `main → dev` (no dev branch exists). Enforcing that by *profile* (not the per-repo `sync_to_dev` flag) makes it impossible to misconfigure.

Both tiers keep release-please versioning + release notes + GitHub Releases.

## Verification

- `actionlint` (v1.7.7, CI's version) clean repo-wide.
- schema JSON + all example YAML parse clean.

## Propagation

Lands in `dev`; reaches `@v3` consumers on the next board `dev → main` promotion. Repo reclassification (3 Fast: nvgt-trunk-plugin, nvgt-repo-template, eslint-config) is follow-up.

Refs NAV-21.