### PR TITLE
fix(pipeline): plumb NPM_TOKEN into semantic-release publish (NAV-41)

### DIFF
--- a/.github/actions/release-management/action.yaml
+++ b/.github/actions/release-management/action.yaml
@@ -7,6 +7,13 @@ inputs:
     description: GitHub token with contents write and pull-requests write permissions
     required: true
 
+  npm-token:
+    description: >-
+      npm registry auth token, consumed by @semantic-release/npm to publish
+      packages. Leave empty for repos that do not publish to npm.
+    required: false
+    default: ''
+
   strategy:
     description: Release strategy (release-please or semantic-release)
     required: false
@@ -264,6 +271,11 @@ runs:
         extra_plugins: ${{ inputs.extra-plugins }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        # @semantic-release/npm reads NPM_TOKEN from the environment and writes
+        # the registry .npmrc itself. Without this, verifyConditions fails with
+        # "No npm token specified" for any repo whose .releaserc enables the npm
+        # plugin (the pipeline previously plumbed no npm auth at all — NAV-41).
+        NPM_TOKEN: ${{ inputs.npm-token }}
 
     - name: Fallback Patch Release (Semantic Release No-Op)
       id: fallback-release

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -1462,6 +1462,7 @@ jobs:
         uses: navigaite/.github/.github/actions/release-management@v3
         with:
           github-token: ${{ steps.app-token.outputs.token || secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
           strategy: ${{ needs.setup.outputs.release-strategy }}
           force-patch-on-no-release: ${{ needs.setup.outputs.release-force-patch-on-no-release }}
           extra-plugins: ${{ needs.setup.outputs.release-extra-plugins }}

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -67,6 +67,10 @@ on:
         value: ${{ jobs.release.outputs.release-tag }}
 
     secrets:
+      # npm publish auth for @semantic-release/npm (release strategy: semantic-release)
+      NPM_TOKEN:
+        required: false
+
       # Vercel secrets
       VERCEL_TOKEN:
         required: false


### PR DESCRIPTION
## Problem
The universal pipeline never plumbed npm auth into the release job. `NPM_TOKEN` appears nowhere in v3, so any repo whose `.releaserc` enables `@semantic-release/npm` fails `verifyConditions` with **"No npm token specified"** on every push to a release branch.

Surfaced on the **first npm-publishing consumer** of the pipeline, `@navigaite/eslint-config` (NAV-41): the dev-push Release Management job goes red ([run 30192522875](https://github.com/navigaite/eslint-config/actions/runs/30192522875)) and no beta is published.

## Fix
- Add optional `npm-token` input to the `release-management` composite action.
- Expose it as `NPM_TOKEN` env on the *Run Semantic Release* step — `@semantic-release/npm` reads it natively and writes the registry `.npmrc` itself.
- Wire it from the caller: `npm-token: ${{ secrets.NPM_TOKEN }}` (org secret, already present).

Repos that do not publish to npm leave it empty → no behaviour change.

## Follow-ups (out of scope here)
- The WORKFLOW_APP token lacks `issues: write`; `@semantic-release/github`'s *fail* plugin errored trying to open the failure issue. Only exercised on release failure — not needed once npm auth works, tracked separately.

Refs NAV-41, NAV-27