### PR TITLE
fix(sync): retire impossible main→dev back-merge; reconcile via auto-merged PR (NAV-50)

### DIFF
--- a/.github/actions/sync-branches/action.yaml
+++ b/.github/actions/sync-branches/action.yaml
@@ -1,15 +1,33 @@
 ---
-name: Sync Branches
-description: Sync changes from main back to dev branch after release (prevents version drift)
+name: Reconcile Dev Manifest
+description: >-
+  After a stable release lands on `main`, reconcile the dev (beta) prerelease
+  release-please manifest base to the just-released stable version and deliver
+  the change via an auto-merged squash PR into `dev`.
+
+  This REPLACES the former `main` -> `dev` back-merge ("sync to dev"). That
+  direct-push back-merge never landed and cannot: `dev` is protected by a
+  ruleset requiring a pull request, signed commits, AND passing status checks,
+  so an unsigned runner `git push` to `dev` is rejected on three counts. Its
+  original purpose — keeping `dev`/`main` reconciled so promotions stay
+  conflict-free — is now handled defensively on the promote side
+  (navigaite/.github#259, NAV-46), which resolves release-managed files to
+  `main` on every `dev` -> `main` promotion. See NAV-50.
+
+  The only remaining job here is the dual-track (Profile B) prerelease-manifest
+  reconcile, which is a genuine recurring need (keeps the next dev beta semver-
+  above the released stable). It is a no-op for non-dual-track repos.
 
 inputs:
   source-branch:
-    description: Source branch to sync from (usually main)
+    description: >-
+      Retained for backward compatibility with existing callers. No longer
+      merged — this action does not back-merge `main` into `dev`.
     required: false
     default: main
 
   target-branch:
-    description: Target branch to sync to (usually dev)
+    description: Target branch to reconcile and open the PR against (usually dev)
     required: false
     default: dev
 
@@ -18,23 +36,26 @@ inputs:
     required: true
 
   create-pr:
-    description: Create a PR instead of direct push
+    description: >-
+      Retained for backward compatibility. Ignored — reconcile changes are
+      always delivered via an auto-merged PR (a direct push to `dev` is
+      impossible under branch protection).
     required: false
     default: 'false'
 
   auto-merge-pr:
-    description: Auto-merge the sync PR (requires create-pr to be true)
+    description: Enable GitHub auto-merge (squash) on the reconcile PR
     required: false
     default: 'true'
 
   prerelease-manifest-file:
     description: >-
-      Path to the dev/beta prerelease release-please manifest. When set
-      together with a different `stable-manifest-file`, the direct-push sync
-      reconciles each prerelease cursor in this file to the just-released
-      stable version (strips the `-beta.N` suffix) so the next dev release
-      computes a version above the released stable. Dual-track (Profile B)
-      repos only; leave empty to disable.
+      Path to the dev/beta prerelease release-please manifest. When set together
+      with a different `stable-manifest-file`, this action reconciles each
+      prerelease cursor in this file to the just-released stable version (strips
+      the `-beta.N` suffix) so the next dev release computes a version above the
+      released stable. Dual-track (Profile B) repos only; leave empty to disable
+      (the action then becomes a clean no-op).
     required: false
     default: ''
 
@@ -64,227 +85,120 @@ runs:
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-    - name: Fetch All Branches
-      shell: bash
-      run: |
-        set -euo pipefail
-        # Fetch remote refs only; never fetch into local checked-out branches.
-        git fetch --prune origin
-
-    - name: Check if Sync is Needed
-      id: check
+    - name: Reconcile dev prerelease manifest via auto-merged PR
+      id: reconcile
       shell: bash
       env:
         SOURCE_BRANCH: ${{ inputs.source-branch }}
         TARGET_BRANCH: ${{ inputs.target-branch }}
+        AUTO_MERGE: ${{ inputs.auto-merge-pr }}
+        PRERELEASE_MANIFEST_FILE: ${{ inputs.prerelease-manifest-file }}
+        STABLE_MANIFEST_FILE: ${{ inputs.stable-manifest-file }}
+        STABLE_VERSION: ${{ inputs.stable-version }}
+        GH_TOKEN: ${{ inputs.github-token }}
       run: |
         set -euo pipefail
-        echo "::group::🔍 Checking if sync is needed"
+        echo "reconciled=false" >> "$GITHUB_OUTPUT"
 
-        # Ensure both remote branches exist
-        git show-ref --verify --quiet "refs/remotes/origin/$SOURCE_BRANCH" || {
-          echo "❌ Source branch origin/$SOURCE_BRANCH not found"
-          exit 1
-        }
+        # Dual-track (Profile B) reconcile only. Everything else is a no-op:
+        # the former main->dev back-merge is retired (handled on the promote
+        # side — see navigaite/.github#259 / NAV-46).
+        if [[ -z "$PRERELEASE_MANIFEST_FILE" || -z "$STABLE_MANIFEST_FILE" \
+              || "$PRERELEASE_MANIFEST_FILE" == "$STABLE_MANIFEST_FILE" ]]; then
+          echo "::notice::Not a dual-track repo — nothing to reconcile. main->dev back-merge is retired (promote-side reconcile handles drift)."
+          exit 0
+        fi
+
+        echo "::group::🔄 Reconciling '$PRERELEASE_MANIFEST_FILE' -> stable"
+
+        # Fetch remote refs only; never fetch into local checked-out branches.
+        git fetch --prune origin
+
         git show-ref --verify --quiet "refs/remotes/origin/$TARGET_BRANCH" || {
           echo "❌ Target branch origin/$TARGET_BRANCH not found"
           exit 1
         }
 
-        # Get the merge-base (common ancestor)
-        MERGE_BASE=$(git merge-base "origin/$SOURCE_BRANCH" "origin/$TARGET_BRANCH")
-
-        # Get the latest commit on source branch
-        SOURCE_COMMIT=$(git rev-parse "origin/$SOURCE_BRANCH")
-
-        # Check if target is already up to date
-        if [[ "$MERGE_BASE" == "$SOURCE_COMMIT" ]]; then
-          echo "✅ $TARGET_BRANCH is already up to date with $SOURCE_BRANCH"
-          echo "needs-sync=false" >> $GITHUB_OUTPUT
-        else
-          echo "📥 $TARGET_BRANCH needs to be synced from $SOURCE_BRANCH"
-          echo "needs-sync=true" >> $GITHUB_OUTPUT
-        fi
-
-        echo "::endgroup::"
-
-    - name: Sync via Direct Push
-      if: steps.check.outputs.needs-sync == 'true' && inputs.create-pr == 'false'
-      shell: bash
-      env:
-        SOURCE_BRANCH: ${{ inputs.source-branch }}
-        TARGET_BRANCH: ${{ inputs.target-branch }}
-        PRERELEASE_MANIFEST_FILE: ${{ inputs.prerelease-manifest-file }}
-        STABLE_MANIFEST_FILE: ${{ inputs.stable-manifest-file }}
-        STABLE_VERSION: ${{ inputs.stable-version }}
-      run: |
-        set -euo pipefail
-        echo "::group::🔄 Syncing $SOURCE_BRANCH → $TARGET_BRANCH"
-
-        # Create/reset local target branch from remote
+        # Work from the current tip of the target branch.
         git checkout -B "$TARGET_BRANCH" "origin/$TARGET_BRANCH"
 
-        # Merge source branch
-        # Use --no-ff to create a merge commit (important for release-please to skip it)
-        # Use special commit message format that release-please ignores
-        git merge "origin/$SOURCE_BRANCH" \
-          --no-ff \
-          --no-edit \
-          -m "chore: sync $SOURCE_BRANCH to $TARGET_BRANCH [skip ci]" \
-          -m "Auto-sync from $SOURCE_BRANCH after release" \
-          -m "This commit contains version updates and should not trigger a new release."
+        bash "$GITHUB_ACTION_PATH/reconcile-prerelease-manifest.sh" \
+          "$PRERELEASE_MANIFEST_FILE" "$STABLE_MANIFEST_FILE" "$STABLE_VERSION"
 
-        # Reconcile the dev (beta) prerelease manifest base to the just-released
-        # stable version so the next dev release computes a version ABOVE the
-        # released stable (dual-track / Profile B repos only). Folded into this
-        # sync push as a separate [skip ci] commit when a change is needed.
-        if [[ -n "$PRERELEASE_MANIFEST_FILE" && -n "$STABLE_MANIFEST_FILE" \
-              && "$PRERELEASE_MANIFEST_FILE" != "$STABLE_MANIFEST_FILE" ]]; then
-          echo "🔧 Reconciling prerelease manifest '$PRERELEASE_MANIFEST_FILE'"
-          bash "$GITHUB_ACTION_PATH/reconcile-prerelease-manifest.sh" \
-            "$PRERELEASE_MANIFEST_FILE" "$STABLE_MANIFEST_FILE" "$STABLE_VERSION"
-          if ! git diff --quiet -- "$PRERELEASE_MANIFEST_FILE"; then
-            git add -- "$PRERELEASE_MANIFEST_FILE"
-            git commit \
-              -m "chore: reconcile $TARGET_BRANCH prerelease manifest base [skip ci]" \
-              -m "Reset prerelease cursor(s) to the just-released stable version after promotion to $SOURCE_BRANCH so the next $TARGET_BRANCH release advances correctly." \
-              -m "This commit should not trigger a new release."
+        if git diff --quiet -- "$PRERELEASE_MANIFEST_FILE"; then
+          echo "✅ dev prerelease manifest already reconciled — no PR needed"
+          echo "::endgroup::"
+          exit 0
+        fi
+
+        # Deliver via an auto-merged squash PR. A direct push to a protected
+        # `dev` is impossible (PR + signatures + checks required); the squash
+        # merge GitHub creates on `dev` is GitHub-signed and passes checks.
+        BRANCH="chore/reconcile-dev-manifest"
+        git checkout -B "$BRANCH"
+        git add -- "$PRERELEASE_MANIFEST_FILE"
+        git commit \
+          -m "chore: reconcile dev prerelease manifest base after stable release" \
+          -m "Reset the dev prerelease cursor(s) in '$PRERELEASE_MANIFEST_FILE' to the just-released stable version so the next dev beta computes ABOVE stable. Delivered as an auto-merged squash PR because a direct push to a protected dev branch is rejected (PR + signed commits + status checks required). See NAV-50."
+        git push origin "HEAD:$BRANCH" --force
+
+        PR_NUMBER=$(gh pr list --head "$BRANCH" --base "$TARGET_BRANCH" \
+          --state open --json number --jq '.[0].number // empty')
+        if [[ -z "$PR_NUMBER" ]]; then
+          PR_URL=$(gh pr create \
+            --head "$BRANCH" \
+            --base "$TARGET_BRANCH" \
+            --title "chore: reconcile dev prerelease manifest base" \
+            --body $'## 🔄 Dual-track manifest reconcile\n\nResets the dev (beta) prerelease cursor(s) to the just-released stable version so the next dev beta stays semver-above stable.\n\nThis replaces the retired `main` → `dev` back-merge (which could never land under dev branch protection). Promotion conflict-freedom is handled on the promote side (navigaite/.github#259).\n\n🤖 Auto-generated by the Universal Pipeline (NAV-50).')
+          PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$' || true)
+          echo "✅ Opened reconcile PR: $PR_URL"
+        else
+          echo "✅ Reconcile PR already open: #$PR_NUMBER"
+        fi
+
+        echo "reconciled=true" >> "$GITHUB_OUTPUT"
+        echo "pr-number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+        if [[ "$AUTO_MERGE" == "true" && -n "$PR_NUMBER" ]]; then
+          if gh pr merge "$PR_NUMBER" --auto --squash --delete-branch; then
+            echo "✅ Auto-merge (squash) enabled on PR #$PR_NUMBER"
           else
-            echo "✅ Prerelease manifest already reconciled — no extra commit"
+            echo "::warning::Could not enable auto-merge on PR #$PR_NUMBER — merge it manually."
           fi
         fi
 
-        # Push to target branch
-        git push origin "$TARGET_BRANCH"
-
-        echo "✅ Successfully synced $SOURCE_BRANCH to $TARGET_BRANCH"
         echo "::endgroup::"
 
-    - name: Create Sync Pull Request
-      if: steps.check.outputs.needs-sync == 'true' && inputs.create-pr == 'true'
-      id: create-pr
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-      with:
-        github-token: ${{ inputs.github-token }}
-        script: |
-          const { data: existingPRs } = await github.rest.pulls.list({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            head: `${context.repo.owner}:${{ inputs.source-branch }}`,
-            base: '${{ inputs.target-branch }}',
-            state: 'open'
-          });
-
-          if (existingPRs.length > 0) {
-            core.info(`✅ Sync PR already exists: #${existingPRs[0].number}`);
-            core.setOutput('pr-number', existingPRs[0].number);
-            core.setOutput('pr-url', existingPRs[0].html_url);
-            return;
-          }
-
-          const { data: pr } = await github.rest.pulls.create({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            title: `chore: sync ${{ inputs.source-branch }} to ${{ inputs.target-branch }}`,
-            head: '${{ inputs.source-branch }}',
-            base: '${{ inputs.target-branch }}',
-            body: `## 🔄 Automated Branch Sync
-
-          This PR syncs changes from \`${{ inputs.source-branch }}\` back to
-          \`${{ inputs.target-branch }}\` after a release.
-
-          ### What's included:
-          - Version updates (package.json, pyproject.toml, etc.)
-          - CHANGELOG updates
-          - Other release-related changes
-
-          ### Why this is needed:
-          After a release is created on \`${{ inputs.source-branch }}\`, the version numbers
-          are bumped. Without this sync, \`${{ inputs.target-branch }}\` would remain on the
-          old version, causing confusion and potential conflicts.
-
-          ### Note:
-          This sync commit will be ignored by release-please and won't appear
-          in future release notes.
-
-          ---
-          🤖 *This PR was created automatically by the Universal Pipeline v2*`
-          });
-
-          core.info(`✅ Created sync PR: #${pr.number}`);
-          core.setOutput('pr-number', pr.number);
-          core.setOutput('pr-url', pr.html_url);
-
-    - name: Auto-Merge Pull Request
-      if: |
-        steps.check.outputs.needs-sync == 'true' &&
-        inputs.create-pr == 'true' &&
-        inputs.auto-merge-pr == 'true' &&
-        steps.create-pr.outputs.pr-number != ''
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-      with:
-        github-token: ${{ inputs.github-token }}
-        script: |
-          const prNumber = ${{ steps.create-pr.outputs.pr-number }};
-
-          // Enable auto-merge
-          try {
-            await github.rest.pulls.merge({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-              merge_method: 'merge', // Use merge commit (not squash)
-              commit_title: `chore: sync ${{ inputs.source-branch }} to ${{ inputs.target-branch }} [skip ci]`,
-              commit_message: 'Auto-sync from ${{ inputs.source-branch }} after release'
-            });
-
-            core.info(`✅ Auto-merged PR #${prNumber}`);
-          } catch (error) {
-            core.warning(`Could not auto-merge PR #${prNumber}: ${error.message}`);
-            core.warning('You may need to merge this PR manually or check branch protection rules.');
-          }
-
-    - name: Sync Summary
+    - name: Reconcile Summary
       if: always()
       shell: bash
       env:
-        NEEDS_SYNC: ${{ steps.check.outputs.needs-sync }}
-        CREATE_PR: ${{ inputs.create-pr }}
-        SOURCE_BRANCH: ${{ inputs.source-branch }}
+        RECONCILED: ${{ steps.reconcile.outputs.reconciled }}
+        PR_NUMBER: ${{ steps.reconcile.outputs.pr-number }}
         TARGET_BRANCH: ${{ inputs.target-branch }}
-        PR_URL: ${{ steps.create-pr.outputs.pr-url }}
-        AUTO_MERGE: ${{ inputs.auto-merge-pr }}
       run: |
         set -euo pipefail
-        echo "### 🔄 Branch Sync" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-
-        if [[ "$NEEDS_SYNC" == "false" ]]; then
-          echo "✅ **No sync needed** - \`$TARGET_BRANCH\` is already up to date" >> $GITHUB_STEP_SUMMARY
-        elif [[ "$CREATE_PR" == "true" ]]; then
-          echo "📝 **Sync PR Created**" >> $GITHUB_STEP_SUMMARY
-          echo "- **From:** \`$SOURCE_BRANCH\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **To:** \`$TARGET_BRANCH\`" >> $GITHUB_STEP_SUMMARY
-          if [[ -n "$PR_URL" ]]; then
-            echo "- **PR:** $PR_URL" >> $GITHUB_STEP_SUMMARY
+        echo "### 🔄 Dev Manifest Reconcile" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        if [[ "$RECONCILED" == "true" ]]; then
+          echo "📝 **Reconcile PR opened** into \`$TARGET_BRANCH\`" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -n "$PR_NUMBER" ]]; then
+            echo "- **PR:** #$PR_NUMBER (auto-merge / squash)" >> "$GITHUB_STEP_SUMMARY"
           fi
-          echo "- **Auto-Merge:** $AUTO_MERGE" >> $GITHUB_STEP_SUMMARY
         else
-          echo "✅ **Synced Successfully**" >> $GITHUB_STEP_SUMMARY
-          echo "- **From:** \`$SOURCE_BRANCH\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **To:** \`$TARGET_BRANCH\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Method:** Direct push" >> $GITHUB_STEP_SUMMARY
+          echo "✅ **No reconcile needed** — dev manifest already ahead of stable, or repo is not dual-track." >> "$GITHUB_STEP_SUMMARY"
         fi
 
 outputs:
   synced:
-    description: Whether branches were synced
-    value: ${{ steps.check.outputs.needs-sync }}
+    description: >-
+      Backward-compat alias. True when a reconcile PR was opened this run.
+    value: ${{ steps.reconcile.outputs.reconciled }}
+
+  reconciled:
+    description: Whether a dev-manifest reconcile PR was opened
+    value: ${{ steps.reconcile.outputs.reconciled }}
 
   pr-number:
-    description: PR number (if created)
-    value: ${{ steps.create-pr.outputs.pr-number }}
-
-  pr-url:
-    description: PR URL (if created)
-    value: ${{ steps.create-pr.outputs.pr-url }}
+    description: Reconcile PR number (if opened)
+    value: ${{ steps.reconcile.outputs.pr-number }}

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -1478,10 +1478,17 @@ jobs:
           release-type: ${{ needs.setup.outputs.release-type != '' && needs.setup.outputs.release-type || (needs.setup.outputs.stack == 'nodejs' && 'node' || needs.setup.outputs.stack == 'python' && 'python' || 'simple') }}
           draft-pull-request: ${{ needs.setup.outputs.release-draft-pull-request }}
   # =============================================================================
-  # SYNC MAIN TO DEV (After Release)
+  # RECONCILE DEV MANIFEST (After Stable Release)
   # =============================================================================
+  # The former `main` -> `dev` back-merge ("sync to dev") is retired: it never
+  # landed and cannot, because `dev` requires a PR + signed commits + status
+  # checks, so an unsigned runner direct-push is rejected. Its purpose
+  # (conflict-free promotions) is now handled defensively on the promote side
+  # (navigaite/.github#259 / NAV-46). This job now only performs the dual-track
+  # (Profile B) prerelease-manifest reconcile, delivered via an auto-merged
+  # squash PR. It is a no-op for non-dual-track repos. See NAV-50.
   sync-to-dev:
-    name: 🔄 Sync to Dev
+    name: 🔄 Reconcile Dev Manifest
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -1525,18 +1532,18 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token || secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - name: 🔄 Sync Branches
+      - name: 🔄 Reconcile Dev Manifest
         uses: navigaite/.github/.github/actions/sync-branches@v3
         with:
           source-branch: main
           target-branch: ${{ needs.setup.outputs.sync-target-branch }}
           github-token: ${{ steps.app-token.outputs.token || secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-          create-pr: false
           auto-merge-pr: true
           # Dual-track (Profile B) reconcile: after the stable release lands on
           # main, reset the dev (beta) prerelease manifest base to the released
-          # stable version so the next dev release stays above stable. No-op
-          # unless both manifests are configured and differ.
+          # stable version so the next dev release stays above stable, delivered
+          # via an auto-merged squash PR. No-op unless both manifests are
+          # configured and differ.
           prerelease-manifest-file: ${{ needs.setup.outputs.release-manifest-file }}
           stable-manifest-file: ${{ needs.setup.outputs.release-manifest-file-stable }}
           stable-version: ${{ needs.release.outputs.release-version }}


### PR DESCRIPTION
## Summary

The `main` → `dev` back-merge ("sync to dev") **has never landed and cannot** — verified: `main` is not an ancestor of `dev`, and there are zero sync commits on `dev`.

**Root cause:** `dev` is protected by a ruleset requiring a **pull request + signed commits + status checks** (`pull_request`, `required_signatures`, `required_status_checks`). The `sync-branches` action did `git merge origin/main --no-ff` then `git push origin dev` — an **unsigned runner direct-push**, rejected on three counts. Even when it didn't conflict, it could never be accepted.

**Why it's safe to retire:** the back-merge's purpose (keep `main`/`dev` reconciled so `dev` → `main` promotions stay conflict-free) is now handled **defensively on the promote side** by #259 (NAV-46), which resolves release-managed files to `main` on every promotion. Drift is now benign.

## What changed

- **Retired** the `main` → `dev` back-merge from `actions/sync-branches`. No more `git merge origin/main` / direct push to `dev`.
- **Kept** the still-needed dual-track (Profile B) prerelease-manifest reconcile — but delivered via an **auto-merged squash PR** into `dev` (GitHub-signed squash commit, passes checks) instead of an impossible direct push. `dev` requires **0 approvals**, so auto-merge completes once Check Gate + Branch Guard pass.
- **No-op** for non-dual-track repos (no manifests configured).
- Reconcile logic + unit tests unchanged — **12/12 pass**.
- Renamed the caller job `Sync to Dev` → `Reconcile Dev Manifest` and refreshed comments.

Propagates org-wide via `@v3`.

Closes NAV-50.