### PR TITLE
fix(ci): allow bot-authored promote/* heads in Branch Guard (NAV-21)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,9 @@ permissions: {}
 jobs:
   # ---------------------------------------------------------------------------
   # Branch guard: PRs targeting dev are always allowed (feature branches land
-  # there). PRs targeting main must be one of: a promotion from dev, an
-  # automated release-please PR, or an emergency hotfix/* — mirrors the
+  # there). PRs targeting main must be one of: a promotion from dev or a
+  # bot-authored promote/* staging branch (NAV-46 conflict-free promotion),
+  # an automated release-please PR, or an emergency hotfix/* — mirrors the
   # pattern other two-branch repos (e.g. edilio) already run.
   #
   # The `if:` also gates on `base.ref == 'main'` (PRI-630). Every code path in
@@ -78,6 +79,36 @@ jobs:
             exit 0
           fi
 
+          if [[ "$PR_HEAD" == promote/* ]]; then
+            # Staging branch built by the promote-to-main workflow (NAV-46):
+            # main + merge(dev) with release-managed files pre-resolved to main.
+            # A raw dev → main PR three-way-conflicts on the changelog/version
+            # manifests every release, so the promote/* branch is the ONLY
+            # conflict-free promotion path. Trusted only when authored by the
+            # pipeline bot — a human-pushed promote/* branch could carry
+            # arbitrary content to main, so gate on author exactly like the
+            # release-please path below.
+            if [[ "$PR_AUTHOR" != "github-actions[bot]" && "$PR_AUTHOR" != "navigaite-workflow-app[bot]" ]]; then
+              echo "::error::❌ promote/* branch author is '$PR_AUTHOR', not the pipeline bot. Promotion staging branches must be created by the promote-to-main workflow."
+              exit 1
+            fi
+            echo "ℹ️  Promotion PR from staging branch $PR_HEAD → main"
+
+            OPEN_RP=$(gh api "repos/$PR_BASE_REPO/pulls" \
+              --paginate \
+              --jq '[.[] | select(
+                .state=="open" and .base.ref=="dev" and
+                (.head.ref | startswith("release-please"))
+              )] | length')
+            if [[ "$OPEN_RP" -gt 0 ]]; then
+              echo "::error::❌ There is an open release-please PR on dev. Merge or close it before promoting to main."
+              exit 1
+            fi
+
+            echo "✅ Promotion allowed — staging branch from pipeline bot, no open release-please PR on dev"
+            exit 0
+          fi
+
           if [[ "$PR_HEAD" == release-please--* ]]; then
             if [[ "$PR_AUTHOR" == "github-actions[bot]" || "$PR_AUTHOR" == "navigaite-workflow-app[bot]" ]]; then
               echo "✅ Release-please PR from bot — allowed"
@@ -94,7 +125,7 @@ jobs:
           fi
 
           echo "::error::❌ PRs targeting main must come from:"
-          echo "::error::  dev (promotion), release-please (bot), or hotfix/* (emergency)."
+          echo "::error::  dev or promote/* (promotion), release-please (bot), or hotfix/* (emergency)."
           echo "::error::Please retarget this PR to dev instead."
           exit 1
 


### PR DESCRIPTION
## Fix: unblock dev → main promotion (Branch Guard vs promote/* deadlock)

### Problem
The board could not merge the v3.3.0 stable promotion (PR #262) — **Branch Guard failed**, and there is currently **no working promotion path at all**:

- **Raw `dev → main` PR** three-way-conflicts on release-managed files (CHANGELOG, package.json, lockfile, extra-files) every release → unmergeable (verified: PR #264 is `CONFLICTING`).
- **NAV-46 `promote-to-main.yaml`** solves that by staging a `promote/*` branch (`main` + `merge(dev)` with release-managed files pre-resolved to `main`) — but **Branch Guard only whitelisted heads named `dev` / `release-please--*` / `hotfix/*`**, so it rejects `promote/*`:
  ```
  ❌ PRs targeting main must come from: dev (promotion), release-please (bot), or hotfix/* (emergency).
  ```
- NAV-50 retired the `main → dev` back-merge, removing the old reconcile path.

NAV-46 (promote workflow) and Branch Guard were merged separately and never reconciled.

### Fix
Whitelist `promote/*` heads in Branch Guard, **gated on the pipeline bot author** (`github-actions[bot]` / `navigaite-workflow-app[bot]`) exactly like the release-please path — a human-pushed `promote/*` branch could otherwise carry arbitrary content to `main`. Re-checks the same "no open release-please PR on `dev`" precondition as the `dev` path. Forks remain blocked by the existing head-repo check above.

Since `pull_request` runs the **head** branch's workflow, a fresh `promote/*` branch built off this fixed `dev` carries the fix and passes — no bootstrap merge to `main` needed.

### After merge
1. Merge the release-please beta PR this opens on `dev`.
2. Re-run `promote-to-main` → fresh `promote/*` PR passes Branch Guard.
3. Board merges the promotion (merge commit) → v3.3.0 stable ships.
4. Close stale #262 and #264.

Refs NAV-21, NAV-33, NAV-46, NAV-50.
