### PR TITLE
ci(promote): automate dev→main promote trigger via app token (NAV-52)

### DIFF
--- a/.github/workflows/promote-to-main.yaml
+++ b/.github/workflows/promote-to-main.yaml
@@ -63,14 +63,50 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Mint a `navigaite-workflow-app` installation token. The promote PR must
+      # be authored by the app, not `github.token`: GitHub suppresses workflow
+      # runs for `GITHUB_TOKEN`-authored PR events (anti-recursion), so a
+      # token-opened promote PR never fires the pipeline and its required checks
+      # stay pending forever. Branch Guard already whitelists the app's
+      # `promote/*` heads. Falls back to `github.token` when the app secrets are
+      # absent (promote PR then needs a manual close/reopen to trigger checks).
+      - name: 🔍 Check for GitHub App secrets
+        id: check-app
+        shell: bash
+        env:
+          APP_ID: ${{ secrets.WORKFLOW_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.WORKFLOW_APP_PRIVATE_KEY }}
+        run: |
+          if [[ -n "$APP_ID" && -n "$APP_PRIVATE_KEY" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            missing=()
+            [[ -z "$APP_ID" ]] && missing+=("WORKFLOW_APP_ID")
+            [[ -z "$APP_PRIVATE_KEY" ]] && missing+=("WORKFLOW_APP_PRIVATE_KEY")
+            echo "::warning::${missing[*]} not set — falling back to GITHUB_TOKEN. The promote PR won't trigger its pipeline until manually reopened."
+          fi
+
+      - name: 🔑 Generate GitHub App token
+        id: app-token
+        if: steps.check-app.outputs.available == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.WORKFLOW_APP_ID }}
+          private-key: ${{ secrets.WORKFLOW_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.base }}
           fetch-depth: 0
+          # Persist the app token (when available) so `git push` of the
+          # `promote/*` branch is attributed to the app and triggers the
+          # pipeline, matching the `gh pr create` author below.
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Open promotion PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           HEAD: ${{ inputs.head }}
           BASE: ${{ inputs.base }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -3,10 +3,17 @@ name: 📤 Promote dev → main
 on:
   workflow_dispatch: {}
 
+# `contents: write` caps the reusable's fallback `GITHUB_TOKEN` high enough to
+# push the `promote/*` staging branch when the GitHub App secrets are absent.
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:
   promote:
     uses: navigaite/.github/.github/workflows/promote-to-main.yaml@v3
+    # `inherit` forwards the org `WORKFLOW_APP_ID`/`WORKFLOW_APP_PRIVATE_KEY`
+    # secrets so the reusable can mint an app token. A `github.token`-authored
+    # promote PR is suppressed by GitHub's anti-recursion rule (required checks
+    # never fire); an app-token-authored PR triggers the pipeline normally.
+    secrets: inherit


### PR DESCRIPTION
## What

Durable fix so board dev→main promotions are one-click, no manual bootstrap. Discovered unblocking v3.3.0 (NAV-21 #267).

### Changes
- **`promote-to-main.yaml`** — mint a `navigaite-workflow-app` installation token (mirrors `release.yaml`): new `check-app` + `app-token` steps run **before** `checkout`; token persisted via `checkout.token` for `git push` and used as `GH_TOKEN` for `gh pr create`. Both branch push and PR are now **app-authored**, so GitHub fires the pipeline (no anti-recursion suppression). Falls back to `github.token` when app secrets absent.
- **`promote.yml`** — `contents: read` → `write` (fallback token must push `promote/*`); add `secrets: inherit` to forward `WORKFLOW_APP_*`.

### Why
`github.token`-authored PR events don't trigger workflows → promote PR checks stay pending → permanently BLOCKED. #267 needed a manual close/reopen. Branch Guard already whitelists the app's `promote/*` heads (#265).

## Acceptance (NAV-52)
- [ ] `promote.yml` dispatch (no bootstrap branch, no close/reopen) → green, mergeable, bot-authored `promote/*` PR — **verifiable only after this reaches `@v3`** (caller pins `@v3`); tracked below.
- [ ] Bootstrap branch `bootstrap/nav21-promote-v330` deleted (post-#267 merge).

Refs #265, #267, NAV-46 (#259), NAV-33.