### PR TITLE
fix(pipeline): point TMPDIR at RUNNER_TEMP on self-hosted jobs (NAV-54)

### DIFF
--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -715,15 +715,6 @@ jobs:
     name: 🔎 Static Checks
     runs-on: ${{ fromJSON(needs.setup.outputs.runner-labels) }}
     timeout-minutes: 15
-    # Hardened rootless self-hosted runners mount /tmp noexec, so tools that
-    # mktemp+exec (the trunk launcher extracts+runs the CLI from a mktemp dir;
-    # prebuilt native binaries do the same) fail with exit 126. Point TMPDIR at
-    # the exec-capable runner workdir so every mktemp lands there. Setting
-    # TRUNK_TMPDIR is not enough: setup/locate_trunk.sh in trunk-action does its
-    # own `mktemp -d` (honoring TMPDIR) and overwrites TRUNK_TMPDIR afterwards.
-    # No-op on GitHub-hosted runners, where RUNNER_TEMP is already exec-capable.
-    env:
-      TMPDIR: ${{ runner.temp }}
     permissions:
       contents: read
       pull-requests: write
@@ -740,6 +731,17 @@ jobs:
       (needs.setup.outputs.enable-security == 'true' || needs.setup.outputs.enable-lint == 'true') &&
       needs.setup.outputs.docs-only != 'true'
     steps:
+      # Hardened rootless self-hosted runners mount /tmp noexec, so tools that
+      # mktemp+exec (the trunk launcher extracts+runs the CLI from its mktemp
+      # dir; prebuilt native binaries do the same) fail with exit 126. Route tmp
+      # to the exec-capable runner workdir for every later step. Setting
+      # TRUNK_TMPDIR is not enough: trunk-action's setup/locate_trunk.sh does its
+      # own `mktemp -d` (honoring TMPDIR) and overwrites TRUNK_TMPDIR afterwards.
+      # No-op on GitHub-hosted runners, where RUNNER_TEMP is already exec-capable.
+      - name: 🧭 Route tmp to exec-capable runner workdir
+        shell: bash
+        run: echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
+
       - name: 📥 Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -979,11 +981,6 @@ jobs:
     name: 🧪 Verify
     runs-on: ${{ fromJSON(needs.setup.outputs.runner-labels) }}
     timeout-minutes: 45
-    # See static-checks: /tmp is noexec on hardened rootless runners. Tests and
-    # builds routinely exec prebuilt binaries from a tmp dir (esbuild, swc,
-    # native modules), so keep tmp on the exec-capable runner workdir.
-    env:
-      TMPDIR: ${{ runner.temp }}
     permissions:
       contents: read
       id-token: write # SLSA attestation + OIDC (build)
@@ -993,6 +990,14 @@ jobs:
       (needs.setup.outputs.enable-test == 'true' || needs.setup.outputs.enable-build == 'true') &&
       needs.setup.outputs.docs-only != 'true'
     steps:
+      # /tmp is noexec on hardened rootless runners; tests/builds exec prebuilt
+      # binaries from a tmp dir (esbuild, swc, native modules). Route tmp to the
+      # exec-capable runner workdir. See static-checks for the full rationale.
+      # No-op on GitHub-hosted runners, where RUNNER_TEMP is already exec-capable.
+      - name: 🧭 Route tmp to exec-capable runner workdir
+        shell: bash
+        run: echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
+
       - name: 📥 Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -1287,10 +1292,6 @@ jobs:
     name: 🐳 Docker / ${{ matrix.image.name }}
     runs-on: ${{ fromJSON(needs.setup.outputs.runner-labels) }}
     timeout-minutes: 20
-    # See static-checks: /tmp is noexec on hardened rootless runners; keep tmp
-    # on the exec-capable runner workdir for any build tooling that mktemp+execs.
-    env:
-      TMPDIR: ${{ runner.temp }}
     permissions:
       contents: read
       deployments: write
@@ -1313,6 +1314,13 @@ jobs:
       matrix:
         image: ${{ fromJSON(needs.setup.outputs.docker-images) }}
     steps:
+      # /tmp is noexec on hardened rootless runners; keep tmp on the exec-capable
+      # runner workdir for build tooling that mktemp+execs. See static-checks.
+      # No-op on GitHub-hosted runners, where RUNNER_TEMP is already exec-capable.
+      - name: 🧭 Route tmp to exec-capable runner workdir
+        shell: bash
+        run: echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
+
       - name: 📥 Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/universal-pipeline.yaml
+++ b/.github/workflows/universal-pipeline.yaml
@@ -715,6 +715,15 @@ jobs:
     name: 🔎 Static Checks
     runs-on: ${{ fromJSON(needs.setup.outputs.runner-labels) }}
     timeout-minutes: 15
+    # Hardened rootless self-hosted runners mount /tmp noexec, so tools that
+    # mktemp+exec (the trunk launcher extracts+runs the CLI from a mktemp dir;
+    # prebuilt native binaries do the same) fail with exit 126. Point TMPDIR at
+    # the exec-capable runner workdir so every mktemp lands there. Setting
+    # TRUNK_TMPDIR is not enough: setup/locate_trunk.sh in trunk-action does its
+    # own `mktemp -d` (honoring TMPDIR) and overwrites TRUNK_TMPDIR afterwards.
+    # No-op on GitHub-hosted runners, where RUNNER_TEMP is already exec-capable.
+    env:
+      TMPDIR: ${{ runner.temp }}
     permissions:
       contents: read
       pull-requests: write
@@ -970,6 +979,11 @@ jobs:
     name: 🧪 Verify
     runs-on: ${{ fromJSON(needs.setup.outputs.runner-labels) }}
     timeout-minutes: 45
+    # See static-checks: /tmp is noexec on hardened rootless runners. Tests and
+    # builds routinely exec prebuilt binaries from a tmp dir (esbuild, swc,
+    # native modules), so keep tmp on the exec-capable runner workdir.
+    env:
+      TMPDIR: ${{ runner.temp }}
     permissions:
       contents: read
       id-token: write # SLSA attestation + OIDC (build)
@@ -1273,6 +1287,10 @@ jobs:
     name: 🐳 Docker / ${{ matrix.image.name }}
     runs-on: ${{ fromJSON(needs.setup.outputs.runner-labels) }}
     timeout-minutes: 20
+    # See static-checks: /tmp is noexec on hardened rootless runners; keep tmp
+    # on the exec-capable runner workdir for any build tooling that mktemp+execs.
+    env:
+      TMPDIR: ${{ runner.temp }}
     permissions:
       contents: read
       deployments: write


### PR DESCRIPTION
## Problem
Hardened rootless org runner `mainz-homelab-navigaite` mounts `/tmp` **noexec**. `trunk-io/trunk-action`'s `setup/locate_trunk.sh` runs `mktemp -d` (honoring `$TMPDIR`, default `/tmp`), downloads the trunk CLI into it, `chmod +x`, and execs it → `Permission denied`, **exit 126**.

Evidence: mietkatalog #799 run job 89781257063 → `/tmp/tmp.dSyOGmWdNJ/trunk: Permission denied`.

Setting `TRUNK_TMPDIR` does **not** work — `locate_trunk.sh` does its own `mktemp -d` and overwrites `TRUNK_TMPDIR` afterwards. The lever that actually redirects that `mktemp` is `TMPDIR`.

## Fix
Set job-level `TMPDIR: ${{ runner.temp }}` on the three self-hosted-capable jobs — `static-checks`, `verify`, `deploy-docker` — so every `mktemp`+exec (trunk launcher, prebuilt native binaries used by tests/builds) lands in the exec-capable runner workdir.

- **No-op on GitHub-hosted runners** — `RUNNER_TEMP` is already exec-capable there.
- Docker-less TruffleHog (v3.3.0) already installs to `${RUNNER_TEMP}/trufflehog-bin`; this closes the remaining trunk wall and any future tmp-exec tool.

## Bootstrap risk — cleared
navigaite/.github's own CI (`ci.yaml` etc.) runs entirely on `ubuntu-latest`, not the hardened runner, so this PR's own checks go green normally.

## Verification
- YAML parses; all three jobs carry `TMPDIR`.
- End-to-end hardened-runner proof requires the rolling `v3` tag to advance (board `dev`→`main` promotion), then re-run mietkatalog #799/#802 on `mainz-homelab-navigaite`.

Refs NAV-54. Unblocks NAV-29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)